### PR TITLE
Vj/head circumference

### DIFF
--- a/docs/fetal_growth_methods.md
+++ b/docs/fetal_growth_methods.md
@@ -1,0 +1,51 @@
+# Fetal Growth Methods: NICHD Tables, Z-Scores, and Hadlock Regression
+
+## NICHD Fetal Growth Tables
+The Eunice Kennedy Shriver National Institute of Child Health and Human Development (NICHD) published growth standards for fetal biometry based on a large, multi-ethnic, prospective U.S. cohort. These tables provide percentile curves (3rd, 5th, 10th, 50th, 90th, 95th, 97th) for measurements such as:
+- Biparietal diameter (BPD)
+- Head circumference (HC)
+- Abdominal circumference (AC)
+- Femur length (FL)
+
+The NICHD tables are stratified by maternal race/ethnicity (e.g., Non-Hispanic White, Non-Hispanic Black, Hispanic, Asian/Pacific Islander) and by gestational age in weeks. For example, at 20 weeks, the 50th percentile head circumference differs across populations. These tables serve as reference standards to determine whether a fetus is small-for-gestational-age (below the 10th percentile) or large-for-gestational-age (above the 90th percentile).
+
+Reference: [NICHD Fetal Growth Calculator Percentile Range](https://www.nichd.nih.gov/sites/default/files/inline-files/FGCalculatorPercentileRange.pdf)
+
+---
+
+## Z-Scores
+A z-score is a standardized measure that expresses how many standard deviations an observed value lies above or below the mean for a given gestational age and population. The formula is:
+
+```
+z = (observed_value - mean_for_age) / standard_deviation_for_age
+```
+
+- z = 0 means the value is exactly average for gestational age.
+- z < -2 typically indicates growth restriction (e.g., microcephaly if applied to head circumference).
+- z > +2 may indicate overgrowth (e.g., macrocephaly for head circumference).
+
+Using z-scores rather than raw percentiles allows continuous assessment of growth across populations and enables combining measurements into regression-based models.
+
+---
+
+## Hadlock Regression Formulas
+Hadlock and colleagues (1980s, Baylor College of Medicine) developed widely used regression models to predict gestational age and estimated fetal weight (EFW) from ultrasound parameters.
+
+### Gestational Age Estimation
+- **Parameters used:** BPD, HC, AC, FL (alone or in combination).
+- **Finding:** Head circumference and femur length were the strongest individual predictors of age.
+- **Regression model:** Multivariate polynomials including linear, quadratic, cubic, and interaction terms (e.g., HC, HC2, HC3, HC x FL).
+- **Accuracy:** Combining parameters reduced variability compared to using BPD alone.
+
+### Estimated Fetal Weight (EFW)
+- **Parameters used:** HC, AC, FL (sometimes BPD).
+- **Finding:** The best models combined at least three parameters (HC or BPD + AC + FL).
+- **Accuracy:** Mean error about 0-2% with standard deviation of +-7-8% of actual birth weight.{index=2}
+- **Clinical use:** Still widely employed in ultrasound machines for fetal weight estimation.
+
+---
+
+## Summary
+- **NICHD tables** provide percentile-based norms stratified by race/ethnicity and gestational age.
+- **Z-scores** standardize measurements relative to the mean, allowing precise classification of abnormal growth.
+- **Hadlock regression formulas** predict gestational age and estimated fetal weight by combining multiple biometric parameters, reducing error compared to single measurements.

--- a/docs/fetal_growth_methods.md
+++ b/docs/fetal_growth_methods.md
@@ -29,7 +29,7 @@ Using z-scores rather than raw percentiles allows continuous assessment of growt
 ---
 
 ## Hadlock Regression Formulas
-Hadlock and colleagues (1980s, Baylor College of Medicine) developed widely used regression models to predict gestational age and estimated fetal weight (EFW) from ultrasound parameters.
+Hadlock and colleagues (1980s, Baylor College of Medicine, (see [**Key References**](#key-references))) developed widely used regression models to predict gestational age and estimated fetal weight (EFW) from ultrasound parameters.
 
 ### Gestational Age Estimation
 - **Parameters used:** BPD, HC, AC, FL (alone or in combination).

--- a/docs/fetal_growth_methods.md
+++ b/docs/fetal_growth_methods.md
@@ -49,3 +49,7 @@ Hadlock and colleagues (1980s, Baylor College of Medicine) developed widely used
 - **NICHD tables** provide percentile-based norms stratified by race/ethnicity and gestational age.
 - **Z-scores** standardize measurements relative to the mean, allowing precise classification of abnormal growth.
 - **Hadlock regression formulas** predict gestational age and estimated fetal weight by combining multiple biometric parameters, reducing error compared to single measurements.
+
+### Key References
+- [Radiology. 1984 Feb;150(2):535-40: *Sonographic estimation of fetal weight. The value of femur length in addition to head and abdomen measurements*](https://pubmed.ncbi.nlm.nih.gov/6691115/){:target="_blank"}
+- [Am J Obstet Gynecol. 1985 Feb;151(3):333-7: *Estimation of fetal weight with the use of head, body, and femur measurements -- a prospective study*](https://www.sciencedirect.com/science/article/pii/0002937885902984?via%3Dihub){:target="_blank"}

--- a/docs/head_circumference.md
+++ b/docs/head_circumference.md
@@ -1,3 +1,18 @@
 # Head Circumference
 
-intro etc.ç
+## Data source
+Head circumference percentile calculations will use **NICHD fetal growth standards**.  
+The current implementation uses **mock reference data** for 20 weeks only.
+
+## Mapping strategy
+1. Look up mean and standard deviation for the measurement at given gestational age.  
+2. Calculate a z-score and convert it to a percentile using the normal distribution.  
+3. Apply thresholds to infer ontology terms:
+  - `< 3rd percentile` -> Microcephaly (HP:0000252)
+  - `> 97th percentile` -> Macrocephaly (HP:0000256)
+  - Otherwise, no term assigned.
+
+## Planned extensions
+- Replace mock reference with full NICHD tables across gestational ages.  
+- Add population-specific standards if available.  
+- Extend to other biometric measures (BPD, AC, FL, EFW).

--- a/src/prenatalppkt/biometry.py
+++ b/src/prenatalppkt/biometry.py
@@ -1,0 +1,91 @@
+"""
+biometry.py
+
+Class-based implementation of prenatal biometric measurements.
+Supports percentile calculation and mapping to ontology terms.
+"""
+
+from statistics import NormalDist
+from dataclasses import dataclass
+from typing import Optional
+from . import constants
+
+
+class BiometryType:
+    """Types of biometric measurements supported by this library."""
+
+    HEAD_CIRCUMFERENCE = "head_circumference"
+    BIPARIETAL_DIAMETER = "biparietal_diameter"
+    ABDOMINAL_CIRCUMFERENCE = "abdominal_circumference"
+    FEMUR_LENGTH = "femur_length"
+    ESTIMATED_FETAL_WEIGHT = "estimated_fetal_weight"
+
+
+# Mock reference data for demonstration purposes.
+# Only head circumference at 20 weeks is currently supported.
+_MOCK_REFERENCES = {
+    BiometryType.HEAD_CIRCUMFERENCE: {
+        20: {"mean": 175.0, "sd": 10.0}  # millimeters
+    }
+}
+
+
+@dataclass
+class BiometryMeasurement:
+    """
+    Represents a single prenatal biometric measurement.
+
+    Attributes
+    ----------
+    measurement_type : str
+        The type of measurement, e.g., BiometryType.HEAD_CIRCUMFERENCE.
+    gestational_age_weeks : float
+        Gestational age in completed weeks.
+    value_mm : float
+        Measurement value in millimeters.
+    """
+
+    measurement_type: str
+    gestational_age_weeks: float
+    value_mm: float
+
+    def percentile_and_hpo(self) -> tuple[float, Optional[str]]:
+        """
+        Calculate the percentile and infer an ontology term if abnormal.
+
+        Returns
+        -------
+        tuple[float, str | None]
+            Percentile (0-100), and HPO identifier if abnormal, else None.
+
+        Raises
+        ------
+        ValueError
+            If the gestational age is invalid or reference data is missing.
+        """
+        if self.gestational_age_weeks < 12 or self.gestational_age_weeks > 40:
+            raise ValueError(
+                f"Unsupported gestational age: {self.gestational_age_weeks} weeks. "
+                "Valid range is 12-40 weeks."
+            )
+
+        ref_table = _MOCK_REFERENCES.get(self.measurement_type, {})
+        if self.gestational_age_weeks not in ref_table:
+            raise ValueError(
+                f"No reference data for {self.measurement_type} at "
+                f"{self.gestational_age_weeks} weeks."
+            )
+
+        ref = ref_table[self.gestational_age_weeks]
+        mean, sd = ref["mean"], ref["sd"]
+
+        z_score = (self.value_mm - mean) / sd
+        percentile = round(NormalDist().cdf(z_score) * 100, 1)
+
+        if self.measurement_type == BiometryType.HEAD_CIRCUMFERENCE:
+            if percentile < 3:
+                return percentile, constants.HPO_MICROCEPHALY
+            if percentile > 97:
+                return percentile, constants.HPO_MACROCEPHALY
+
+        return percentile, None

--- a/src/prenatalppkt/constants.py
+++ b/src/prenatalppkt/constants.py
@@ -1,0 +1,14 @@
+"""
+constants.py
+
+Ontology identifiers and fixed values for prenatal biometry mappings.
+Keeping them centralized makes updates and maintenance easier.
+"""
+
+# Human Phenotype Ontology (HPO) term identifiers
+
+HPO_MICROCEPHALY: str = "HP:0000252"
+"""Microcephaly: head circumference significantly below expected size."""
+
+HPO_MACROCEPHALY: str = "HP:0000256"
+"""Macrocephaly: head circumference significantly above expected size."""

--- a/tests/test_biometry.py
+++ b/tests/test_biometry.py
@@ -1,0 +1,66 @@
+"""
+test_biometry.py
+
+Unit tests for BiometryMeasurement and head circumference mapping.
+"""
+
+import pytest
+from prenatalppkt.biometry import BiometryMeasurement, BiometryType
+from prenatalppkt import constants
+
+
+def test_head_circumference_normal_case():
+    """A normal head circumference should be ~50th percentile with no HPO term."""
+    measure = BiometryMeasurement(
+        measurement_type=BiometryType.HEAD_CIRCUMFERENCE,
+        gestational_age_weeks=20,
+        value_mm=175,
+    )
+    pct, hpo = measure.percentile_and_hpo()
+    assert 40 <= pct <= 60
+    assert hpo is None
+
+
+@pytest.mark.parametrize(
+    "value_mm, expected_hpo",
+    [(130, constants.HPO_MICROCEPHALY), (210, constants.HPO_MACROCEPHALY)],
+)
+def test_head_circumference_abnormal_cases(value_mm, expected_hpo):
+    """Extremely small or large head circumference should map to the correct HPO term."""
+    measure = BiometryMeasurement(
+        measurement_type=BiometryType.HEAD_CIRCUMFERENCE,
+        gestational_age_weeks=20,
+        value_mm=value_mm,
+    )
+    _, hpo = measure.percentile_and_hpo()
+    assert hpo == expected_hpo
+
+
+def test_invalid_gestational_age_raises_error():
+    """Gestational ages outside 12-40 weeks should raise ValueError."""
+    measure = BiometryMeasurement(
+        measurement_type=BiometryType.HEAD_CIRCUMFERENCE,
+        gestational_age_weeks=2,
+        value_mm=100,
+    )
+    with pytest.raises(ValueError):
+        measure.percentile_and_hpo()
+
+    measure = BiometryMeasurement(
+        measurement_type=BiometryType.HEAD_CIRCUMFERENCE,
+        gestational_age_weeks=45,
+        value_mm=200,
+    )
+    with pytest.raises(ValueError):
+        measure.percentile_and_hpo()
+
+
+def test_missing_reference_data_raises_error():
+    """Gestational age within 12-40 but missing from reference should raise ValueError."""
+    measure = BiometryMeasurement(
+        measurement_type=BiometryType.HEAD_CIRCUMFERENCE,
+        gestational_age_weeks=18,  # not in mock reference
+        value_mm=150,
+    )
+    with pytest.raises(ValueError):
+        measure.percentile_and_hpo()


### PR DESCRIPTION
feat: add BiometryMeasurement class and head circumference mapping

- Introduce BiometryType for supported biometric measurement kinds
- Implement BiometryMeasurement dataclass with percentile_and_hpo()
- Add ontology constants for microcephaly and macrocephaly
- Provide mock reference for head circumference at 20 weeks
- Add pytest tests for normal, abnormal, and edge cases