### PR TITLE
Vj/resolve-oop-violation

### DIFF
--- a/data/mappings/biometry_hpo_mappings.yaml
+++ b/data/mappings/biometry_hpo_mappings.yaml
@@ -22,6 +22,15 @@
 #     bins:
 #       <bin_key>: {id: "...", label: "..."} or null
 
+# "below_3p": lower_extreme_term,
+# "between_3p_5p": lower_term,
+# "between_5p_10p": abnormal_term,
+# "between_10p_50p": normal_term,
+# "between_50p_90p": normal_term,
+# "between_90p_95p": abnormal_term,
+# "between_95p_97p": upper_term,
+# "above_97p": upper_extreme_term,
+
 
 head_circumference:
  abnormal_term:

--- a/data/mappings/biometry_hpo_mappings.yaml
+++ b/data/mappings/biometry_hpo_mappings.yaml
@@ -56,14 +56,14 @@ biparietal_diameter:
  normal_bins: ["between_10p_50p", "between_50p_90p"]
 
  bins:
-   below_3p:        { id: "HP:0005484", label: "Secondary microcephaly" }
+   below_3p:        { id: "HP:0011451", label: "Primary microcephaly" }
    between_3p_5p:   null  # no specific HPO term found
    between_5p_10p:  { id: "HP:0000240", label: "Abnormality of skull size" }
    between_10p_50p: null  # Normal range
    between_50p_90p: null  # Normal range
    between_90p_95p: { id: "HP:0000240", label: "Abnormality of skull size" }
    between_95p_97p: null  # no specific HPO term found
-   above_97p:       { id: "HP:0005490", label: "Postnatal macrocephaly" }
+   above_97p:       { id: "HP:0004488", label: "Macrocephaly at birth" }
 
 
 femur_length:

--- a/src/prenatalppkt/measurements/abdominal_circumference_measurement.py
+++ b/src/prenatalppkt/measurements/abdominal_circumference_measurement.py
@@ -1,0 +1,22 @@
+"""
+abdominal_circumference_measurement.py
+
+Defines `AbdominalCircumferenceMeasurement`, representing fetal abdominal
+circumference (AC). Automatically registered under `"abdominal_circumference"`.
+"""
+
+from __future__ import annotations
+from prenatalppkt.sonographic_measurement import SonographicMeasurement
+
+
+class AbdominalCircumferenceMeasurement(SonographicMeasurement, measurement_type="abdominal_circumference"):
+   """Represents a fetal abdominal circumference (AC) measurement."""
+
+    def __init__(self) -> None:
+        """Initialize BPD measurement."""
+        super().__init__()
+
+   
+   def name(self) -> str:
+       """Return the canonical name for this measurement."""
+       return "abdominal circumference"

--- a/src/prenatalppkt/measurements/abdominal_circumference_measurement.py
+++ b/src/prenatalppkt/measurements/abdominal_circumference_measurement.py
@@ -9,14 +9,15 @@ from __future__ import annotations
 from prenatalppkt.sonographic_measurement import SonographicMeasurement
 
 
-class AbdominalCircumferenceMeasurement(SonographicMeasurement, measurement_type="abdominal_circumference"):
-   """Represents a fetal abdominal circumference (AC) measurement."""
+class AbdominalCircumferenceMeasurement(
+    SonographicMeasurement, measurement_type="abdominal_circumference"
+):
+    """Represents a fetal abdominal circumference (AC) measurement."""
 
     def __init__(self) -> None:
         """Initialize BPD measurement."""
         super().__init__()
 
-   
-   def name(self) -> str:
-       """Return the canonical name for this measurement."""
-       return "abdominal circumference"
+    def name(self) -> str:
+        """Return the canonical name for this measurement."""
+        return "abdominal circumference"

--- a/src/prenatalppkt/measurements/bpd_measurement.py
+++ b/src/prenatalppkt/measurements/bpd_measurement.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 from prenatalppkt.sonographic_measurement import SonographicMeasurement
 
 
-class BiparietalDiameterMeasurement(SonographicMeasurement):
+class BiparietalDiameterMeasurement(
+    SonographicMeasurement, measurement_type="biparietal_diameter"
+):
     """
     Represents a sonographic measurement of fetal biparietal diameter (BPD).
 

--- a/src/prenatalppkt/measurements/femur_length_measurement.py
+++ b/src/prenatalppkt/measurements/femur_length_measurement.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from prenatalppkt.sonographic_measurement import SonographicMeasurement
 
 
-class FemurLengthMeasurement(SonographicMeasurement):
+class FemurLengthMeasurement(SonographicMeasurement, measurement_type="femur_length"):
     """
     Represents a sonographic measurement of fetal femur length (FL).
 

--- a/src/prenatalppkt/measurements/head_circumference_measurement.py
+++ b/src/prenatalppkt/measurements/head_circumference_measurement.py
@@ -1,0 +1,25 @@
+"""
+head_circumference_measurement.py
+
+Defines `HeadCircumferenceMeasurement`, a subclass of `SonographicMeasurement`
+for fetal head circumference (HC) evaluation.
+
+Automatically registered under `"head_circumference"`.
+"""
+
+from __future__ import annotations
+from prenatalppkt.sonographic_measurement import SonographicMeasurement
+
+
+class HeadCircumferenceMeasurement(
+    SonographicMeasurement, measurement_type="head_circumference"
+):
+    """Represents a sonographic measurement of fetal head circumference (HC)."""
+
+    def __init__(self) -> None:
+        """Initialize HC measurement."""
+        super().__init__()
+
+    def name(self) -> str:
+        """Return the canonical name for this measurement."""
+        return "head circumference"

--- a/src/prenatalppkt/measurements/occipitofrontal_diameter_measurement.py
+++ b/src/prenatalppkt/measurements/occipitofrontal_diameter_measurement.py
@@ -9,14 +9,15 @@ from __future__ import annotations
 from prenatalppkt.sonographic_measurement import SonographicMeasurement
 
 
-class OccipitofrontalDiameterMeasurement(SonographicMeasurement, measurement_type="occipitofrontal_diameter"):
-   """Represents a sonographic measurement of fetal occipitofrontal diameter (OFD)."""
+class OccipitofrontalDiameterMeasurement(
+    SonographicMeasurement, measurement_type="occipitofrontal_diameter"
+):
+    """Represents a sonographic measurement of fetal occipitofrontal diameter (OFD)."""
 
     def __init__(self) -> None:
         """Initialize OFD measurement."""
         super().__init__()
 
-   
-   def name(self) -> str:
-       """Return the canonical name for this measurement."""
-       return "occipitofrontal diameter"
+    def name(self) -> str:
+        """Return the canonical name for this measurement."""
+        return "occipitofrontal diameter"

--- a/src/prenatalppkt/measurements/occipitofrontal_diameter_measurement.py
+++ b/src/prenatalppkt/measurements/occipitofrontal_diameter_measurement.py
@@ -1,0 +1,22 @@
+"""
+occipitofrontal_diameter_measurement.py
+
+Defines `OccipitofrontalDiameterMeasurement`, representing fetal abdominal
+occipitofrontal diameter (OFD). Registered under `"occipitofrontal_diameter"`.
+"""
+
+from __future__ import annotations
+from prenatalppkt.sonographic_measurement import SonographicMeasurement
+
+
+class OccipitofrontalDiameterMeasurement(SonographicMeasurement, measurement_type="occipitofrontal_diameter"):
+   """Represents a sonographic measurement of fetal occipitofrontal diameter (OFD)."""
+
+    def __init__(self) -> None:
+        """Initialize OFD measurement."""
+        super().__init__()
+
+   
+   def name(self) -> str:
+       """Return the canonical name for this measurement."""
+       return "occipitofrontal diameter"

--- a/src/prenatalppkt/phenotypic_export.py
+++ b/src/prenatalppkt/phenotypic_export.py
@@ -1,215 +1,224 @@
 """
 phenotypic_export.py
 
-Provides a unified API for converting fetal biometric measurements into
-ontology-aware phenotypic observations suitable for Phenopacket export.
+Unified API for converting fetal biometric measurements into
+ontology-aware `TermObservation` objects suitable for Phenopacket export.
 
-This module bridges:
-- Quantitative evaluation (percentile bins via FetalGrowthPercentiles)
-- Structural measurement classes (SonographicMeasurement subclasses)
-- Ontology mapping (TermObservation with HPO terms)
+Refactor summary (Issue #27)
+----------------------------
+- Replaced fragile subclass lookup (`measurement_type_map`) with a
+ robust registry pattern via `SonographicMeasurement`.
+- Enforced a consistent return type: `TermObservation` only.
+- Split `evaluate_and_export` into:
+   * `evaluate_to_observation()` - evaluation + mapping
+   * `export_feature()` - serialization to dict
+- Improved docstrings, error handling, and separation of concerns.
 """
 
 from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import Dict, Optional, Set, List
-import typing
 import yaml
 import json
 
 from prenatalppkt.biometry_reference import FetalGrowthPercentiles
 from prenatalppkt.gestational_age import GestationalAge
 from prenatalppkt.measurements.reference_range import ReferenceRange
+from prenatalppkt.measurements.measurement_result import MeasurementResult
 from prenatalppkt.term_observation import TermObservation
+from prenatalppkt.sonographic_measurement import SonographicMeasurement
 from hpotk import MinimalTerm
 
 logger = logging.getLogger(__name__)
 
-# Default mappings file location
 MAPPINGS_DIR = Path(__file__).resolve().parent.parents[1] / "data" / "mappings"
 DEFAULT_MAPPINGS_FILE = MAPPINGS_DIR / "biometry_hpo_mappings.yaml"
 
 
 class PhenotypicExporter:
-    """
-    Unified exporter for fetal biometric measurements to phenotypic observations.
+   """
+   High-level interface for phenotype export.
 
-    Responsibilities
-    ----------------
-    1. Load percentile reference data (INTERGROWTH or NIHCD)
-    2. Evaluate raw measurements against percentile thresholds
-    3. Map percentile bins to HPO terms via configurable mappings
-    4. Export results as Phenopacket-compatible dictionaries
+   Responsibilities
+   ----------------
+   - Evaluate biometric values against gestational-age reference data.
+   - Map percentile bins to ontology terms.
+   - Return clean, ontology-aware `TermObservation` objects.
 
-    Attributes
-    ----------
-    source : str
-        Reference data source ("intergrowth" or "nichd")
-    reference : FetalGrowthPercentiles
-        Loaded percentile reference tables
-    mappings : dict
-        HPO term mappings for each measurement type
-    normal_bins : set[str]
-        Default percentile bins considered "normal"
-    """
+   Attributes
+   ----------
+   source : str
+       Reference dataset name ("intergrowth" or "nichd").
+   reference : FetalGrowthPercentiles
+       Percentile lookup tables.
+   mappings : dict
+       Measurement-specific ontology configuration.
+   """
 
-    def __init__(
-        self,
-        source: str = "intergrowth",
-        mappings_file: Optional[Path] = None,
-        normal_bins: Optional[Set[str]] = None,
-    ):
-        if source not in {"intergrowth", "nichd"}:
-            raise ValueError(f"Unsupported source: {source}")
+   def __init__(
+       self,
+       source: str = "intergrowth",
+       mappings_file: Optional[Path] = None,
+       normal_bins: Optional[Set[str]] = None,
+   ):
+       if source not in {"intergrowth", "nichd"}:
+           raise ValueError(f"Unsupported source: {source}")
 
-        self.source = source
-        self.reference = FetalGrowthPercentiles(source=source)
-        mappings_path = mappings_file or DEFAULT_MAPPINGS_FILE
-        self.mappings = self._load_mappings(mappings_path)
-        self.normal_bins = normal_bins or {"between_10p_50p", "between_50p_90p"}
+       self.source = source
+       self.reference = FetalGrowthPercentiles(source=source)
+       mappings_path = mappings_file or DEFAULT_MAPPINGS_FILE
+       self.mappings = self._load_mappings(mappings_path)
+       self.normal_bins = normal_bins or {"between_10p_50p", "between_50p_90p"}
 
-        logger.info(f"PhenotypicExporter initialized with source={source}")
+       logger.info(f"PhenotypicExporter initialized with source={source}")
 
-    def _load_mappings(self, path: Path) -> dict:
-        """Load HPO term mappings from YAML configuration file."""
-        if not path.exists():
-            logger.warning(f"Mappings file not found: {path}. Using empty mappings.")
-            return {}
+   # ------------------------------------------------------------------ #
+   # Mapping loader
+   # ------------------------------------------------------------------ #
+   def _load_mappings(self, path: Path) -> dict:
+       """Load and parse HPO term mappings from YAML."""
+       if not path.exists():
+           logger.warning(f"Mappings file not found: {path}. Using empty mappings.")
+           return {}
 
-        with open(path, "r") as f:
-            raw_mappings = yaml.safe_load(f)
+       with open(path, "r") as f:
+           raw_mappings = yaml.safe_load(f)
 
-        processed = {}
-        for meas_type, cfg in raw_mappings.items():
-            bins_cfg = cfg["bins"]
-            abnormal_cfg = cfg["abnormal_term"]
-            normal_bins = set(cfg.get("normal_bins", []))
+       processed = {}
+       for meas_type, cfg in raw_mappings.items():
+           bins_cfg = cfg["bins"]
+           abnormal_cfg = cfg["abnormal_term"]
+           normal_bins = set(cfg.get("normal_bins", []))
 
-            # Convert bins -> MinimalTerm
-            bins = {}
-            for k, v in bins_cfg.items():
-                if v is None:
-                    bins[k] = None
-                else:
-                    bins[k] = MinimalTerm.create_minimal_term(
-                        term_id=v["id"],
-                        name=v["label"],
-                        alt_term_ids=(),
-                        is_obsolete=False,
-                    )
+           # Convert bins -> MinimalTerm
+           bins = {}
+           for k, v in bins_cfg.items():
+               if v is None:
+                   bins[k] = None
+               else:
+                   bins[k] = MinimalTerm.create_minimal_term(
+                       term_id=v["id"], name=v["label"], alt_term_ids=(), is_obsolete=False
+                   )
 
-            abnormal_term = MinimalTerm.create_minimal_term(
-                term_id=abnormal_cfg["id"],
-                name=abnormal_cfg["label"],
-                alt_term_ids=(),
-                is_obsolete=False,
-            )
+           abnormal_term = MinimalTerm.create_minimal_term(
+               term_id=abnormal_cfg["id"],
+               name=abnormal_cfg["label"],
+               alt_term_ids=(),
+               is_obsolete=False,
+           )
 
-            processed[meas_type] = {
-                "bins": bins,
-                "normal_bins": normal_bins,
-                "abnormal_term": abnormal_term,
-            }
-        return processed
+           processed[meas_type] = {
+               "bins": bins,
+               "normal_bins": normal_bins,
+               "abnormal_term": abnormal_term,
+           }
+       return processed
 
-    def evaluate_and_export(
-        self,
-        measurement_type: str,
-        value_mm: float,
-        gestational_age_weeks: float,
-        population: Optional[str] = None,
-        normal_bins: Optional[Set[str]] = None,
-    ) -> typing.Dict[str, str]:
-        """
-        Evaluate a fetal biometric measurement and export as Phenopacket-style dict.
+   # ------------------------------------------------------------------ #
+   # Evaluation and export (refactored)
+   # ------------------------------------------------------------------ #
+   def evaluate_to_observation(
+       self,
+       measurement_type: str,
+       value_mm: float,
+       gestational_age_weeks: float,
+       population: Optional[str] = None,
+       normal_bins: Optional[Set[str]] = None,
+   ) -> TermObservation:
+       """
+       Evaluate a fetal biometric measurement and return a TermObservation.
 
-        Supports both stepwise (MeasurementResult) and ontology-direct
-        (TermObservation) subclasses transparently.
-        """
-        ga = GestationalAge.from_weeks(gestational_age_weeks)
+       Steps:
+       1. Retrieve gestational-age-specific thresholds.
+       2. Instantiate the registered measurement subclass.
+       3. Evaluate the measurement into a `MeasurementResult`.
+       4. Map percentile bin to ontology terms using YAML configuration.
 
-        # Step 2: Lookup reference thresholds
-        try:
-            df = self.reference.tables[measurement_type]["ct"]
-            row = df.loc[df["Gestational Age (weeks)"].round(1) == round(ga.weeks, 1)]
-            if row.empty:
-                raise ValueError(
-                    f"No reference data for {measurement_type} at GA={ga.weeks}w"
-                )
-            percentile_cols = [
-                c
-                for c in df.columns
-                if "percentile" in c.lower() and c != "Gestational Age (weeks)"
-            ]
-            thresholds = row[percentile_cols].iloc[0].astype(float).tolist()
-        except KeyError:
-            raise ValueError(
-                f"Measurement type '{measurement_type}' not available in {self.source} reference"
-            )
+       Returns
+       -------
+       TermObservation
+       Raises
+       ------
+       KeyError
+           If measurement type is not registered.
+       ValueError
+           If reference data is missing.
+       """
+       ga = GestationalAge.from_weeks(gestational_age_weeks)
 
-        # Step 3: Evaluate (may return MeasurementResult or TermObservation)
-        ref_range = ReferenceRange(gestational_age=ga, percentiles=thresholds)
-        measurement_result = ref_range.evaluate(value_mm)
+       # Step 1: Lookup reference thresholds
+       try:
+           df = self.reference.tables[measurement_type]["ct"]
+           row = df.loc[df["Gestational Age (weeks)"].round(1) == round(ga.weeks, 1)]
+           if row.empty:
+               raise ValueError(f"No reference data for {measurement_type} at GA={ga.weeks}w")
 
-        # Step 4: Optional subclass override
-        subclass = None
-        try:
-            from prenatalppkt.measurements import measurement_type_map  # optional
+           percentile_cols = [
+               c
+               for c in df.columns
+               if "percentile" in c.lower() and c != "Gestational Age (weeks)"
+           ]
+           thresholds = row[percentile_cols].iloc[0].astype(float).tolist()
+       except KeyError:
+           raise ValueError(
+               f"Measurement type '{measurement_type}' not available in {self.source} reference"
+           )
 
-            subclass = measurement_type_map.get(measurement_type)
-        except Exception:
-            pass
+       # Step 2: Get subclass (strict registry-based polymorphism)
+       if measurement_type not in SonographicMeasurement.registry:
+           raise KeyError(
+               f"Measurement type '{measurement_type}' is not registered. "
+               "Ensure a SonographicMeasurement subclass defines it."
+           )
 
-        if subclass is not None:
-            instance = subclass()
-            res = instance.evaluate(ga, value_mm, ref_range)
-            if isinstance(res, TermObservation):
-                return res.to_phenotypic_feature()
-            measurement_result = res
+       measurement_cls = SonographicMeasurement.registry[measurement_type]
+       instance = measurement_cls()
 
-        # Step 5: Map to ontology
-        cfg = self.mappings[measurement_type]
-        bin_to_term = cfg["bins"]
-        normal_bins_to_use = normal_bins or cfg["normal_bins"]
-        abnormal_term = cfg["abnormal_term"]
+       # Step 3: Evaluate numeric result
+       ref_range = ReferenceRange(gestational_age=ga, percentiles=thresholds)
+       measurement_result = instance.evaluate(ga, value_mm, ref_range)
+       if not isinstance(measurement_result, MeasurementResult):
+           raise TypeError(f"{measurement_cls.__name__}.evaluate() must return a MeasurementResult")
 
-        if isinstance(measurement_result, TermObservation):
-            term_obs = measurement_result
-        else:
-            term_obs = TermObservation.from_measurement_result(
-                measurement_result=measurement_result,
-                bin_to_term=bin_to_term,
-                gestational_age=ga,
-                normal_bins=normal_bins_to_use,
-                abnormal_term=abnormal_term,
-            )
+       # Step 4: Map to ontology
+       cfg = self.mappings[measurement_type]
+       term_obs = TermObservation.from_measurement_result(
+           measurement_result=measurement_result,
+           bin_to_term=cfg["bins"],
+           gestational_age=ga,
+           normal_bins=normal_bins or cfg["normal_bins"],
+           abnormal_term=cfg["abnormal_term"],
+       )
+       return term_obs
 
-        # Step 6: Serialize for Phenopacket
-        return term_obs.to_phenotypic_feature()
+   # ------------------------------------------------------------------ #
+   # Wrapper for serialization
+   # ------------------------------------------------------------------ #
+   def export_feature(
+       self,
+       measurement_type: str,
+       value_mm: float,
+       gestational_age_weeks: float,
+       **kwargs,
+   ) -> dict:
+       """Serialize a TermObservation as a Phenopacket-style dictionary."""
+       obs = self.evaluate_to_observation(measurement_type, value_mm, gestational_age_weeks, **kwargs)
+       return obs.to_phenotypic_feature()
 
-    def batch_export(self, measurements: List[Dict[str, float]]) -> List[dict]:
-        """
-        Export multiple measurements to phenotypic features.
+   def batch_export(self, measurements: List[Dict[str, float]]) -> List[dict]:
+       """Export multiple measurements to Phenopacket-style features."""
+       results = []
+       for meas in measurements:
+           try:
+               results.append(self.export_feature(**meas))
+           except Exception as e:
+               logger.error(f"Failed to export measurement {meas}: {e}")
+               results.append({"error": str(e), "measurement": meas})
+       return results
 
-        Notes
-        -----
-        We intentionally wrap each iteration in a `try`/`except` block so that
-        a single measurement failure does not interrupt batch export. Ruff warns
-        about `PERF203` (try/except inside loop), but this is acceptable here
-        because robustness is more important than marginal performance.
-        """
-        results = []
-        for meas in measurements:
-            try:
-                results.append(self.evaluate_and_export(**meas))
-            except Exception as e:  # noqa: PERF203 - per-measurement isolation is intentional
-                logger.error(f"Failed to export measurement {meas}: {e}")
-                results.append({"error": str(e), "measurement": meas})
-        return results
-
-    def to_json(self, measurements: List[Dict[str, float]], pretty: bool = True) -> str:
-        """Export batch measurements to JSON string."""
-        results = self.batch_export(measurements)
-        indent = 2 if pretty else None
-        return json.dumps(results, indent=indent)
+   def to_json(self, measurements: List[Dict[str, float]], pretty: bool = True) -> str:
+       """Export batch measurements to JSON string."""
+       results = self.batch_export(measurements)
+       indent = 2 if pretty else None
+       return json.dumps(results, indent=indent)

--- a/src/prenatalppkt/phenotypic_export.py
+++ b/src/prenatalppkt/phenotypic_export.py
@@ -120,7 +120,7 @@ class PhenotypicExporter:
         gestational_age_weeks: float,
         population: Optional[str] = None,
         normal_bins: Optional[Set[str]] = None,
-    ) -> typing.Dict[str,str]:
+    ) -> typing.Dict[str, str]:
         """
         Evaluate a fetal biometric measurement and export as Phenopacket-style dict.
 

--- a/src/prenatalppkt/phenotypic_export.py
+++ b/src/prenatalppkt/phenotypic_export.py
@@ -37,188 +37,197 @@ DEFAULT_MAPPINGS_FILE = MAPPINGS_DIR / "biometry_hpo_mappings.yaml"
 
 
 class PhenotypicExporter:
-   """
-   High-level interface for phenotype export.
+    """
+    High-level interface for phenotype export.
 
-   Responsibilities
-   ----------------
-   - Evaluate biometric values against gestational-age reference data.
-   - Map percentile bins to ontology terms.
-   - Return clean, ontology-aware `TermObservation` objects.
+    Responsibilities
+    ----------------
+    - Evaluate biometric values against gestational-age reference data.
+    - Map percentile bins to ontology terms.
+    - Return clean, ontology-aware `TermObservation` objects.
 
-   Attributes
-   ----------
-   source : str
-       Reference dataset name ("intergrowth" or "nichd").
-   reference : FetalGrowthPercentiles
-       Percentile lookup tables.
-   mappings : dict
-       Measurement-specific ontology configuration.
-   """
+    Attributes
+    ----------
+    source : str
+        Reference dataset name ("intergrowth" or "nichd").
+    reference : FetalGrowthPercentiles
+        Percentile lookup tables.
+    mappings : dict
+        Measurement-specific ontology configuration.
+    """
 
-   def __init__(
-       self,
-       source: str = "intergrowth",
-       mappings_file: Optional[Path] = None,
-       normal_bins: Optional[Set[str]] = None,
-   ):
-       if source not in {"intergrowth", "nichd"}:
-           raise ValueError(f"Unsupported source: {source}")
+    def __init__(
+        self,
+        source: str = "intergrowth",
+        mappings_file: Optional[Path] = None,
+        normal_bins: Optional[Set[str]] = None,
+    ):
+        if source not in {"intergrowth", "nichd"}:
+            raise ValueError(f"Unsupported source: {source}")
 
-       self.source = source
-       self.reference = FetalGrowthPercentiles(source=source)
-       mappings_path = mappings_file or DEFAULT_MAPPINGS_FILE
-       self.mappings = self._load_mappings(mappings_path)
-       self.normal_bins = normal_bins or {"between_10p_50p", "between_50p_90p"}
+        self.source = source
+        self.reference = FetalGrowthPercentiles(source=source)
+        mappings_path = mappings_file or DEFAULT_MAPPINGS_FILE
+        self.mappings = self._load_mappings(mappings_path)
+        self.normal_bins = normal_bins or {"between_10p_50p", "between_50p_90p"}
 
-       logger.info(f"PhenotypicExporter initialized with source={source}")
+        logger.info(f"PhenotypicExporter initialized with source={source}")
 
-   # ------------------------------------------------------------------ #
-   # Mapping loader
-   # ------------------------------------------------------------------ #
-   def _load_mappings(self, path: Path) -> dict:
-       """Load and parse HPO term mappings from YAML."""
-       if not path.exists():
-           logger.warning(f"Mappings file not found: {path}. Using empty mappings.")
-           return {}
+    # ------------------------------------------------------------------ #
+    # Mapping loader
+    # ------------------------------------------------------------------ #
+    def _load_mappings(self, path: Path) -> dict:
+        """Load and parse HPO term mappings from YAML."""
+        if not path.exists():
+            logger.warning(f"Mappings file not found: {path}. Using empty mappings.")
+            return {}
 
-       with open(path, "r") as f:
-           raw_mappings = yaml.safe_load(f)
+        with open(path, "r") as f:
+            raw_mappings = yaml.safe_load(f)
 
-       processed = {}
-       for meas_type, cfg in raw_mappings.items():
-           bins_cfg = cfg["bins"]
-           abnormal_cfg = cfg["abnormal_term"]
-           normal_bins = set(cfg.get("normal_bins", []))
+        processed = {}
+        for meas_type, cfg in raw_mappings.items():
+            bins_cfg = cfg["bins"]
+            abnormal_cfg = cfg["abnormal_term"]
+            normal_bins = set(cfg.get("normal_bins", []))
 
-           # Convert bins -> MinimalTerm
-           bins = {}
-           for k, v in bins_cfg.items():
-               if v is None:
-                   bins[k] = None
-               else:
-                   bins[k] = MinimalTerm.create_minimal_term(
-                       term_id=v["id"], name=v["label"], alt_term_ids=(), is_obsolete=False
-                   )
+            # Convert bins -> MinimalTerm
+            bins = {}
+            for k, v in bins_cfg.items():
+                if v is None:
+                    bins[k] = None
+                else:
+                    bins[k] = MinimalTerm.create_minimal_term(
+                        term_id=v["id"],
+                        name=v["label"],
+                        alt_term_ids=(),
+                        is_obsolete=False,
+                    )
 
-           abnormal_term = MinimalTerm.create_minimal_term(
-               term_id=abnormal_cfg["id"],
-               name=abnormal_cfg["label"],
-               alt_term_ids=(),
-               is_obsolete=False,
-           )
+            abnormal_term = MinimalTerm.create_minimal_term(
+                term_id=abnormal_cfg["id"],
+                name=abnormal_cfg["label"],
+                alt_term_ids=(),
+                is_obsolete=False,
+            )
 
-           processed[meas_type] = {
-               "bins": bins,
-               "normal_bins": normal_bins,
-               "abnormal_term": abnormal_term,
-           }
-       return processed
+            processed[meas_type] = {
+                "bins": bins,
+                "normal_bins": normal_bins,
+                "abnormal_term": abnormal_term,
+            }
+        return processed
 
-   # ------------------------------------------------------------------ #
-   # Evaluation and export (refactored)
-   # ------------------------------------------------------------------ #
-   def evaluate_to_observation(
-       self,
-       measurement_type: str,
-       value_mm: float,
-       gestational_age_weeks: float,
-       population: Optional[str] = None,
-       normal_bins: Optional[Set[str]] = None,
-   ) -> TermObservation:
-       """
-       Evaluate a fetal biometric measurement and return a TermObservation.
+    # ------------------------------------------------------------------ #
+    # Evaluation and export (refactored)
+    # ------------------------------------------------------------------ #
+    def evaluate_to_observation(
+        self,
+        measurement_type: str,
+        value_mm: float,
+        gestational_age_weeks: float,
+        population: Optional[str] = None,
+        normal_bins: Optional[Set[str]] = None,
+    ) -> TermObservation:
+        """
+        Evaluate a fetal biometric measurement and return a TermObservation.
 
-       Steps:
-       1. Retrieve gestational-age-specific thresholds.
-       2. Instantiate the registered measurement subclass.
-       3. Evaluate the measurement into a `MeasurementResult`.
-       4. Map percentile bin to ontology terms using YAML configuration.
+        Steps:
+        1. Retrieve gestational-age-specific thresholds.
+        2. Instantiate the registered measurement subclass.
+        3. Evaluate the measurement into a `MeasurementResult`.
+        4. Map percentile bin to ontology terms using YAML configuration.
 
-       Returns
-       -------
-       TermObservation
-       Raises
-       ------
-       KeyError
-           If measurement type is not registered.
-       ValueError
-           If reference data is missing.
-       """
-       ga = GestationalAge.from_weeks(gestational_age_weeks)
+        Returns
+        -------
+        TermObservation
+        Raises
+        ------
+        KeyError
+            If measurement type is not registered.
+        ValueError
+            If reference data is missing.
+        """
+        ga = GestationalAge.from_weeks(gestational_age_weeks)
 
-       # Step 1: Lookup reference thresholds
-       try:
-           df = self.reference.tables[measurement_type]["ct"]
-           row = df.loc[df["Gestational Age (weeks)"].round(1) == round(ga.weeks, 1)]
-           if row.empty:
-               raise ValueError(f"No reference data for {measurement_type} at GA={ga.weeks}w")
+        # Step 1: Lookup reference thresholds
+        try:
+            df = self.reference.tables[measurement_type]["ct"]
+            row = df.loc[df["Gestational Age (weeks)"].round(1) == round(ga.weeks, 1)]
+            if row.empty:
+                raise ValueError(
+                    f"No reference data for {measurement_type} at GA={ga.weeks}w"
+                )
 
-           percentile_cols = [
-               c
-               for c in df.columns
-               if "percentile" in c.lower() and c != "Gestational Age (weeks)"
-           ]
-           thresholds = row[percentile_cols].iloc[0].astype(float).tolist()
-       except KeyError:
-           raise ValueError(
-               f"Measurement type '{measurement_type}' not available in {self.source} reference"
-           )
+            percentile_cols = [
+                c
+                for c in df.columns
+                if "percentile" in c.lower() and c != "Gestational Age (weeks)"
+            ]
+            thresholds = row[percentile_cols].iloc[0].astype(float).tolist()
+        except KeyError:
+            raise ValueError(
+                f"Measurement type '{measurement_type}' not available in {self.source} reference"
+            )
 
-       # Step 2: Get subclass (strict registry-based polymorphism)
-       if measurement_type not in SonographicMeasurement.registry:
-           raise KeyError(
-               f"Measurement type '{measurement_type}' is not registered. "
-               "Ensure a SonographicMeasurement subclass defines it."
-           )
+        # Step 2: Get subclass (strict registry-based polymorphism)
+        if measurement_type not in SonographicMeasurement.registry:
+            raise KeyError(
+                f"Measurement type '{measurement_type}' is not registered. "
+                "Ensure a SonographicMeasurement subclass defines it."
+            )
 
-       measurement_cls = SonographicMeasurement.registry[measurement_type]
-       instance = measurement_cls()
+        measurement_cls = SonographicMeasurement.registry[measurement_type]
+        instance = measurement_cls()
 
-       # Step 3: Evaluate numeric result
-       ref_range = ReferenceRange(gestational_age=ga, percentiles=thresholds)
-       measurement_result = instance.evaluate(ga, value_mm, ref_range)
-       if not isinstance(measurement_result, MeasurementResult):
-           raise TypeError(f"{measurement_cls.__name__}.evaluate() must return a MeasurementResult")
+        # Step 3: Evaluate numeric result
+        ref_range = ReferenceRange(gestational_age=ga, percentiles=thresholds)
+        measurement_result = instance.evaluate(ga, value_mm, ref_range)
+        if not isinstance(measurement_result, MeasurementResult):
+            raise TypeError(
+                f"{measurement_cls.__name__}.evaluate() must return a MeasurementResult"
+            )
 
-       # Step 4: Map to ontology
-       cfg = self.mappings[measurement_type]
-       term_obs = TermObservation.from_measurement_result(
-           measurement_result=measurement_result,
-           bin_to_term=cfg["bins"],
-           gestational_age=ga,
-           normal_bins=normal_bins or cfg["normal_bins"],
-           abnormal_term=cfg["abnormal_term"],
-       )
-       return term_obs
+        # Step 4: Map to ontology
+        cfg = self.mappings[measurement_type]
+        term_obs = TermObservation.from_measurement_result(
+            measurement_result=measurement_result,
+            bin_to_term=cfg["bins"],
+            gestational_age=ga,
+            normal_bins=normal_bins or cfg["normal_bins"],
+            abnormal_term=cfg["abnormal_term"],
+        )
+        return term_obs
 
-   # ------------------------------------------------------------------ #
-   # Wrapper for serialization
-   # ------------------------------------------------------------------ #
-   def export_feature(
-       self,
-       measurement_type: str,
-       value_mm: float,
-       gestational_age_weeks: float,
-       **kwargs,
-   ) -> dict:
-       """Serialize a TermObservation as a Phenopacket-style dictionary."""
-       obs = self.evaluate_to_observation(measurement_type, value_mm, gestational_age_weeks, **kwargs)
-       return obs.to_phenotypic_feature()
+    # ------------------------------------------------------------------ #
+    # Wrapper for serialization
+    # ------------------------------------------------------------------ #
+    def export_feature(
+        self,
+        measurement_type: str,
+        value_mm: float,
+        gestational_age_weeks: float,
+        **kwargs,
+    ) -> dict:
+        """Serialize a TermObservation as a Phenopacket-style dictionary."""
+        obs = self.evaluate_to_observation(
+            measurement_type, value_mm, gestational_age_weeks, **kwargs
+        )
+        return obs.to_phenotypic_feature()
 
-   def batch_export(self, measurements: List[Dict[str, float]]) -> List[dict]:
-       """Export multiple measurements to Phenopacket-style features."""
-       results = []
-       for meas in measurements:
-           try:
-               results.append(self.export_feature(**meas))
-           except Exception as e:
-               logger.error(f"Failed to export measurement {meas}: {e}")
-               results.append({"error": str(e), "measurement": meas})
-       return results
+    def batch_export(self, measurements: List[Dict[str, float]]) -> List[dict]:
+        """Export multiple measurements to Phenopacket-style features."""
+        results = []
+        for meas in measurements:
+            try:
+                results.append(self.export_feature(**meas))
+            except Exception as e:
+                logger.error(f"Failed to export measurement {meas}: {e}")
+                results.append({"error": str(e), "measurement": meas})
+        return results
 
-   def to_json(self, measurements: List[Dict[str, float]], pretty: bool = True) -> str:
-       """Export batch measurements to JSON string."""
-       results = self.batch_export(measurements)
-       indent = 2 if pretty else None
-       return json.dumps(results, indent=indent)
+    def to_json(self, measurements: List[Dict[str, float]], pretty: bool = True) -> str:
+        """Export batch measurements to JSON string."""
+        results = self.batch_export(measurements)
+        indent = 2 if pretty else None
+        return json.dumps(results, indent=indent)

--- a/src/prenatalppkt/phenotypic_export.py
+++ b/src/prenatalppkt/phenotypic_export.py
@@ -221,7 +221,7 @@ class PhenotypicExporter:
         for meas in measurements:
             try:
                 results.append(self.export_feature(**meas))
-            except Exception as e:
+            except Exception as e:  # noqa: PERF203 - intentional isolation for per-measurement robustness
                 logger.error(f"Failed to export measurement {meas}: {e}")
                 results.append({"error": str(e), "measurement": meas})
         return results

--- a/src/prenatalppkt/sonographic_measurement.py
+++ b/src/prenatalppkt/sonographic_measurement.py
@@ -54,7 +54,7 @@ class SonographicMeasurement(ABC):
     # ------------------------------------------------------------------ #
     # Automatic registry for subclasses
     # ------------------------------------------------------------------ #
-    registry: dict[str, type["SonographicMeasurement"]] = {}
+    registry: ClassVar[dict[str, type["SonographicMeasurement"]]] = {}
 
     def __init_subclass__(cls, measurement_type: str, **kwargs):
         """

--- a/src/prenatalppkt/sonographic_measurement.py
+++ b/src/prenatalppkt/sonographic_measurement.py
@@ -23,7 +23,7 @@ Key improvements (OOP refactor)
 
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import Optional, Dict
+from typing import Optional, Dict, ClassVar
 from hpotk import MinimalTerm
 from prenatalppkt.gestational_age import GestationalAge
 from prenatalppkt.measurements.measurement_result import MeasurementResult

--- a/src/prenatalppkt/sonographic_measurement.py
+++ b/src/prenatalppkt/sonographic_measurement.py
@@ -9,32 +9,16 @@ Purpose
 -------
 This class provides a unified interface for evaluating a raw measurement value
 against gestational-age-specific percentile thresholds (`ReferenceRange.evaluate()`),
-returning a `MeasurementResult` object that encodes the percentile bin, and optionally
-converting that result into a `TermObservation` that maps the bin to ontology terms.
+returning a `MeasurementResult` that encodes the percentile bin, and optionally
+converting that result into a `TermObservation`.
 
-Unlike earlier versions, `SonographicMeasurement` itself no longer stores or configures
-ontology mappings. Ontology mapping has been relocated to `TermObservation` to ensure
-clean separation of concerns and testability. The class therefore only returns a
-structural TermObservation indicating whether a measurement is within or outside the
-expected range.
-
-Usage
------
-A typical evaluation workflow looks like this:
-
-  # Step 1: Compute the percentile bin
-  result = bpd.evaluate(ga, 155.0, reference_range)
-
-  # Step 2-5: Convert the bin to a TermObservation
-  mapping = TermObservation.build_standard_bin_mapping(
-      lower_extreme_term=microcephaly,
-      lower_term=decreased_head_circumference,
-      abnormal_term=abnormal_skull_size,
-      normal_term=normal_skull_morphology,
-      upper_term=increased_head_circumference,
-      upper_extreme_term=macrocephaly,
-  )
-  obs = bpd.to_term_observation(result, ga, parent_term=skull_measurement)
+Key improvements (OOP refactor)
+-------------------------------
+- Added automatic subclass registration via `__init_subclass__` for clean
+ polymorphism (no dynamic lookups or fragile imports).
+- Enforced consistent evaluation interface (must return `MeasurementResult`).
+- Clarified docstrings to highlight strict separation between numeric and
+ ontology evaluation.
 """
 
 from __future__ import annotations
@@ -47,120 +31,109 @@ from prenatalppkt.term_observation import TermObservation
 
 
 class SonographicMeasurement(ABC):
-    """
-    Abstract base class for a fetal sonographic measurement.
+   """
+   Abstract base class for a fetal sonographic measurement.
 
-    Responsibilities
-    ----------------
-    1. **Percentile evaluation** -
-        Calls `ReferenceRange.evaluate(value)` to determine which percentile bin
-        a raw measurement falls into, returning a `MeasurementResult`.
+   Responsibilities
+   ----------------
+   1. **Percentile evaluation** -
+       Implements `evaluate()` to determine which percentile bin a raw
+       measurement falls into. Always returns a `MeasurementResult`.
 
-    2. **Delegated ontology mapping** -
-        Provides the convenience wrapper `to_term_observation()` which translates
-        a `MeasurementResult` into a `TermObservation` using the subclass's bin->term mapping.
+   2. **Subclass registry** -
+       Subclasses register automatically under a canonical name (e.g.
+       "head_circumference"), allowing lookup by exporters or other tools
+       without fragile import-time maps.
 
-    3. **Subclass extensibility** -
-        Each subclass (e.g., `BiparietalDiameterMeasurement`) overrides
-        `get_bin_to_term_mapping()` or defines measurement-specific metadata.
+   3. **Optional ontology mapping** -
+       The `to_term_observation()` convenience method can convert a
+       MeasurementResult into a TermObservation, but the canonical
+       ontology mapping happens downstream.
+   """
 
-    By decoupling evaluation from ontology mapping, this design preserves clean
-    separation of logic (numeric evaluation vs semantic interpretation).
-    """
+   # ------------------------------------------------------------------ #
+   # Automatic registry for subclasses
+   # ------------------------------------------------------------------ #
+   registry: dict[str, type["SonographicMeasurement"]] = {}
 
-    # ------------------------------------------------------------------ #
-    # Abstract metadata
-    # ------------------------------------------------------------------ #
-    @abstractmethod
-    def name(self) -> str:
-        """Return the canonical name for this measurement (e.g., 'biparietal diameter')."""
-        raise NotImplementedError
+   def __init_subclass__(cls, measurement_type: str, **kwargs):
+       """
+       Automatically register each subclass under its declared measurement type.
+       Example:
+           class HeadCircumferenceMeasurement(SonographicMeasurement, measurement_type="head_circumference"):
+               ...
+       """
+       super().__init_subclass__(**kwargs)
+       SonographicMeasurement.registry[measurement_type] = cls
 
-    # ------------------------------------------------------------------ #
-    # Core evaluation
-    # ------------------------------------------------------------------ #
-    def evaluate(
-        self, gestational_age: GestationalAge, measurement_value: float, reference_range
-    ) -> MeasurementResult:
-        """
-        Evaluate a raw measurement against the provided reference range.
+   # ------------------------------------------------------------------ #
+   # Abstract metadata
+   # ------------------------------------------------------------------ #
+   @abstractmethod
+   def name(self) -> str:
+       """Return the canonical name for this measurement (e.g., 'biparietal diameter')."""
+       raise NotImplementedError
 
-        Returns
-        -------
-        MeasurementResult
-            Encodes which percentile interval the value falls into.
+   # ------------------------------------------------------------------ #
+   # Core evaluation
+   # ------------------------------------------------------------------ #
+   def evaluate(
+       self, gestational_age: GestationalAge, measurement_value: float, reference_range
+   ) -> MeasurementResult:
+       """
+       Evaluate a raw measurement against the provided reference range.
 
-        Notes
-        -----
-        This method intentionally returns a `MeasurementResult` rather than a
-        `TermObservation`. Ontology mapping (bin -> HPO term) is performed later
-        by the exporter or by `to_term_observation()`.
+       Returns
+       -------
+       MeasurementResult
+           Encodes which percentile interval the value falls into.
 
-        Subclasses may override this method to return a `TermObservation`
-        directly if they wish to encapsulate both steps, but the exporter
-        will handle either type safely.
-        """
-        return reference_range.evaluate(measurement_value)
+       Notes
+       -----
+       Subclasses should not override this unless they need special handling.
+       Ontology mapping happens in TermObservation or the exporter layer.
+       """
+       return reference_range.evaluate(measurement_value)
 
-        # NOTE(@VarenyaJ): Evaluation remains numeric-only for now.
-        # Mapping to ontology happens downstream (TermObservation).
+   # ------------------------------------------------------------------ #
+   # Convenience ontology conversion
+   # ------------------------------------------------------------------ #
+   def to_term_observation(
+       self,
+       measurement_result: MeasurementResult,
+       gestational_age: GestationalAge,
+       parent_term: Optional[MinimalTerm] = None,
+   ) -> TermObservation:
+       """
+       Convert a MeasurementResult into a minimal TermObservation
+       (mainly for debugging or basic interoperability).
 
-    # ------------------------------------------------------------------ #
-    # Structural TermObservation
-    # ------------------------------------------------------------------ #
-    def to_term_observation(
-        self,
-        measurement_result: MeasurementResult,
-        gestational_age: GestationalAge,
-        parent_term: Optional[MinimalTerm] = None,
-    ) -> TermObservation:
-        """
-        Convert a MeasurementResult into a TermObservation.
+       Parameters
+       ----------
+       measurement_result : MeasurementResult
+           The evaluated percentile bin.
+       gestational_age : GestationalAge
+           Gestational context.
+       parent_term : Optional[MinimalTerm]
+           The anatomical/measurement-level ontology term (e.g. "Abnormality of skull size").
+       """
+       observed = measurement_result.bin_key not in {
+           "between_10p_50p",
+           "between_50p_90p",
+       }
+       return TermObservation(
+           hpo_term=parent_term, observed=observed, gestational_age=gestational_age
+       )
 
-        This helps us later perform Steps 2-5 of the classic evaluation workflow:
-
-            Step 2 - Resolve percentile bin -> ontology term using mapping
-            Step 3 - Handle missing or normal bins (mark as unobserved)
-            Step 4 - Determine observed flag (exclude 10th-90th)
-            Step 5 - Return standardized TermObservation
-
-        Parameters
-        ----------
-        measurement_result : MeasurementResult
-            The evaluated percentile bin.
-        gestational_age : GestationalAge
-            Gestational context.
-        parent_term : Optional[MinimalTerm]
-            The anatomical/measurement-level ontology term
-            (e.g. "Abnormality of skull size").
-
-        Returns
-        -------
-        TermObservation
-            A minimal observation object with observed/excluded status.
-        """
-        # Observed = True for abnormal bins (outside 10th-90th percentile)
-        observed = measurement_result.bin_key not in {
-            "between_10p_50p",
-            "between_50p_90p",
-        }
-        return TermObservation(
-            hpo_term=parent_term, observed=observed, gestational_age=gestational_age
-        )
-
-    def get_bin_to_term_mapping(self) -> Dict[str, Optional[MinimalTerm]]:
-        """
-        Placeholder for a default mapping of percentile bins to ontology terms.
-
-        This lives in the superclass so all measurement subclasses share the
-        same baseline structure. Each subclass may override this in a later
-        ontology integration phase.
-        """
-        return TermObservation.build_standard_bin_mapping(
-            lower_extreme_term=None,
-            lower_term=None,
-            abnormal_term=None,
-            normal_term=None,
-            upper_term=None,
-            upper_extreme_term=None,
-        )
+   def get_bin_to_term_mapping(self) -> Dict[str, Optional[MinimalTerm]]:
+       """
+       Optional default bin->term mapping (usually overridden or configured externally).
+       """
+       return TermObservation.build_standard_bin_mapping(
+           lower_extreme_term=None,
+           lower_term=None,
+           abnormal_term=None,
+           normal_term=None,
+           upper_term=None,
+           upper_extreme_term=None,
+       )

--- a/src/prenatalppkt/sonographic_measurement.py
+++ b/src/prenatalppkt/sonographic_measurement.py
@@ -56,15 +56,15 @@ class SonographicMeasurement(ABC):
     # ------------------------------------------------------------------ #
     registry: ClassVar[dict[str, type["SonographicMeasurement"]]] = {}
 
-    def __init_subclass__(cls, measurement_type: str, **kwargs):
+    def __init_subclass__(cls, measurement_type: Optional[str] = None, **kwargs):
         """
-        Automatically register each subclass under its declared measurement type.
-        Example:
-            class HeadCircumferenceMeasurement(SonographicMeasurement, measurement_type="head_circumference"):
-                ...
+        Automatically register subclasses in the measurement registry.
+
+        If `measurement_type` is not explicitly provided, it defaults to the lowercase class name with 'Measurement' stripped (e.g., 'BiparietalDiameterMeasurement' -> 'biparietaldiameter').
         """
         super().__init_subclass__(**kwargs)
-        SonographicMeasurement.registry[measurement_type] = cls
+        key = measurement_type or cls.__name__.replace("Measurement", "").lower()
+        cls.registry[key] = cls
 
     # ------------------------------------------------------------------ #
     # Abstract metadata

--- a/src/prenatalppkt/sonographic_measurement.py
+++ b/src/prenatalppkt/sonographic_measurement.py
@@ -31,109 +31,109 @@ from prenatalppkt.term_observation import TermObservation
 
 
 class SonographicMeasurement(ABC):
-   """
-   Abstract base class for a fetal sonographic measurement.
+    """
+    Abstract base class for a fetal sonographic measurement.
 
-   Responsibilities
-   ----------------
-   1. **Percentile evaluation** -
-       Implements `evaluate()` to determine which percentile bin a raw
-       measurement falls into. Always returns a `MeasurementResult`.
+    Responsibilities
+    ----------------
+    1. **Percentile evaluation** -
+        Implements `evaluate()` to determine which percentile bin a raw
+        measurement falls into. Always returns a `MeasurementResult`.
 
-   2. **Subclass registry** -
-       Subclasses register automatically under a canonical name (e.g.
-       "head_circumference"), allowing lookup by exporters or other tools
-       without fragile import-time maps.
+    2. **Subclass registry** -
+        Subclasses register automatically under a canonical name (e.g.
+        "head_circumference"), allowing lookup by exporters or other tools
+        without fragile import-time maps.
 
-   3. **Optional ontology mapping** -
-       The `to_term_observation()` convenience method can convert a
-       MeasurementResult into a TermObservation, but the canonical
-       ontology mapping happens downstream.
-   """
+    3. **Optional ontology mapping** -
+        The `to_term_observation()` convenience method can convert a
+        MeasurementResult into a TermObservation, but the canonical
+        ontology mapping happens downstream.
+    """
 
-   # ------------------------------------------------------------------ #
-   # Automatic registry for subclasses
-   # ------------------------------------------------------------------ #
-   registry: dict[str, type["SonographicMeasurement"]] = {}
+    # ------------------------------------------------------------------ #
+    # Automatic registry for subclasses
+    # ------------------------------------------------------------------ #
+    registry: dict[str, type["SonographicMeasurement"]] = {}
 
-   def __init_subclass__(cls, measurement_type: str, **kwargs):
-       """
-       Automatically register each subclass under its declared measurement type.
-       Example:
-           class HeadCircumferenceMeasurement(SonographicMeasurement, measurement_type="head_circumference"):
-               ...
-       """
-       super().__init_subclass__(**kwargs)
-       SonographicMeasurement.registry[measurement_type] = cls
+    def __init_subclass__(cls, measurement_type: str, **kwargs):
+        """
+        Automatically register each subclass under its declared measurement type.
+        Example:
+            class HeadCircumferenceMeasurement(SonographicMeasurement, measurement_type="head_circumference"):
+                ...
+        """
+        super().__init_subclass__(**kwargs)
+        SonographicMeasurement.registry[measurement_type] = cls
 
-   # ------------------------------------------------------------------ #
-   # Abstract metadata
-   # ------------------------------------------------------------------ #
-   @abstractmethod
-   def name(self) -> str:
-       """Return the canonical name for this measurement (e.g., 'biparietal diameter')."""
-       raise NotImplementedError
+    # ------------------------------------------------------------------ #
+    # Abstract metadata
+    # ------------------------------------------------------------------ #
+    @abstractmethod
+    def name(self) -> str:
+        """Return the canonical name for this measurement (e.g., 'biparietal diameter')."""
+        raise NotImplementedError
 
-   # ------------------------------------------------------------------ #
-   # Core evaluation
-   # ------------------------------------------------------------------ #
-   def evaluate(
-       self, gestational_age: GestationalAge, measurement_value: float, reference_range
-   ) -> MeasurementResult:
-       """
-       Evaluate a raw measurement against the provided reference range.
+    # ------------------------------------------------------------------ #
+    # Core evaluation
+    # ------------------------------------------------------------------ #
+    def evaluate(
+        self, gestational_age: GestationalAge, measurement_value: float, reference_range
+    ) -> MeasurementResult:
+        """
+        Evaluate a raw measurement against the provided reference range.
 
-       Returns
-       -------
-       MeasurementResult
-           Encodes which percentile interval the value falls into.
+        Returns
+        -------
+        MeasurementResult
+            Encodes which percentile interval the value falls into.
 
-       Notes
-       -----
-       Subclasses should not override this unless they need special handling.
-       Ontology mapping happens in TermObservation or the exporter layer.
-       """
-       return reference_range.evaluate(measurement_value)
+        Notes
+        -----
+        Subclasses should not override this unless they need special handling.
+        Ontology mapping happens in TermObservation or the exporter layer.
+        """
+        return reference_range.evaluate(measurement_value)
 
-   # ------------------------------------------------------------------ #
-   # Convenience ontology conversion
-   # ------------------------------------------------------------------ #
-   def to_term_observation(
-       self,
-       measurement_result: MeasurementResult,
-       gestational_age: GestationalAge,
-       parent_term: Optional[MinimalTerm] = None,
-   ) -> TermObservation:
-       """
-       Convert a MeasurementResult into a minimal TermObservation
-       (mainly for debugging or basic interoperability).
+    # ------------------------------------------------------------------ #
+    # Convenience ontology conversion
+    # ------------------------------------------------------------------ #
+    def to_term_observation(
+        self,
+        measurement_result: MeasurementResult,
+        gestational_age: GestationalAge,
+        parent_term: Optional[MinimalTerm] = None,
+    ) -> TermObservation:
+        """
+        Convert a MeasurementResult into a minimal TermObservation
+        (mainly for debugging or basic interoperability).
 
-       Parameters
-       ----------
-       measurement_result : MeasurementResult
-           The evaluated percentile bin.
-       gestational_age : GestationalAge
-           Gestational context.
-       parent_term : Optional[MinimalTerm]
-           The anatomical/measurement-level ontology term (e.g. "Abnormality of skull size").
-       """
-       observed = measurement_result.bin_key not in {
-           "between_10p_50p",
-           "between_50p_90p",
-       }
-       return TermObservation(
-           hpo_term=parent_term, observed=observed, gestational_age=gestational_age
-       )
+        Parameters
+        ----------
+        measurement_result : MeasurementResult
+            The evaluated percentile bin.
+        gestational_age : GestationalAge
+            Gestational context.
+        parent_term : Optional[MinimalTerm]
+            The anatomical/measurement-level ontology term (e.g. "Abnormality of skull size").
+        """
+        observed = measurement_result.bin_key not in {
+            "between_10p_50p",
+            "between_50p_90p",
+        }
+        return TermObservation(
+            hpo_term=parent_term, observed=observed, gestational_age=gestational_age
+        )
 
-   def get_bin_to_term_mapping(self) -> Dict[str, Optional[MinimalTerm]]:
-       """
-       Optional default bin->term mapping (usually overridden or configured externally).
-       """
-       return TermObservation.build_standard_bin_mapping(
-           lower_extreme_term=None,
-           lower_term=None,
-           abnormal_term=None,
-           normal_term=None,
-           upper_term=None,
-           upper_extreme_term=None,
-       )
+    def get_bin_to_term_mapping(self) -> Dict[str, Optional[MinimalTerm]]:
+        """
+        Optional default bin->term mapping (usually overridden or configured externally).
+        """
+        return TermObservation.build_standard_bin_mapping(
+            lower_extreme_term=None,
+            lower_term=None,
+            abnormal_term=None,
+            normal_term=None,
+            upper_term=None,
+            upper_extreme_term=None,
+        )

--- a/src/prenatalppkt/term_observation.py
+++ b/src/prenatalppkt/term_observation.py
@@ -85,19 +85,22 @@ class TermObservation:
         abnormal_term: Optional["MinimalTerm"] = None,
     ) -> TermObservation:
         """
-        Convert a MeasurementResult into a TermObservation.
-
-        This is the canonical bridge between numeric evaluation
-        and ontology interpretation, as used by PhenotypicExporter.
+        Convert a MeasurementResult into a TermObservation using a bin->term mapping.
         """
         bin_key = measurement_result.bin_key
         hpo_term = bin_to_term.get(bin_key)
 
         if normal_bins and bin_key in normal_bins:
+            # For normal bins -> use parent abnormal term, mark excluded
             hpo_term = abnormal_term
             observed = False
+        elif hpo_term is None:
+            # For abnormal bins with no specific term -> use abnormal_term as fallback
+            hpo_term = abnormal_term
+            observed = True
         else:
-            observed = bool(hpo_term)
+            # Have a specific term for this bin
+            observed = True
 
         return TermObservation(
             hpo_term=hpo_term, observed=observed, gestational_age=gestational_age

--- a/src/prenatalppkt/term_observation.py
+++ b/src/prenatalppkt/term_observation.py
@@ -20,105 +20,112 @@ from prenatalppkt.measurements.measurement_result import MeasurementResult
 
 @dataclass
 class TermObservation:
-   """
-   Represents an ontology-based interpretation of a MeasurementResult.
+    """
+    Represents an ontology-based interpretation of a MeasurementResult.
 
-   Attributes
-   ----------
-   hpo_term : Optional[MinimalTerm]
-       The ontology term representing the phenotype (e.g., "Microcephaly").
-   observed : bool
-       True if abnormality observed; False if excluded (normal finding).
-   gestational_age : GestationalAge
-       Context for interpretation.
-   """
+    Attributes
+    ----------
+    hpo_term : Optional[MinimalTerm]
+        The ontology term representing the phenotype (e.g., "Microcephaly").
+    observed : bool
+        True if abnormality observed; False if excluded (normal finding).
+    gestational_age : GestationalAge
+        Context for interpretation.
+    """
 
-   hpo_term: Optional[MinimalTerm]
-   observed: bool
-   gestational_age: GestationalAge
-   parent_term: Optional[MinimalTerm] = None
-   hpo_id: str = ""
-   hpo_label: str = ""
+    hpo_term: Optional[MinimalTerm]
+    observed: bool
+    gestational_age: GestationalAge
+    parent_term: Optional[MinimalTerm] = None
+    hpo_id: str = ""
+    hpo_label: str = ""
 
-   def __post_init__(self) -> None:
-       """Derive identifiers and labels from MinimalTerm."""
-       if self.hpo_term and isinstance(self.hpo_term, MinimalTerm):
-           self.hpo_id = str(getattr(self.hpo_term, "identifier", ""))
-           self.hpo_label = getattr(self.hpo_term, "name", "")
+    def __post_init__(self) -> None:
+        """Derive identifiers and labels from MinimalTerm."""
+        if self.hpo_term and isinstance(self.hpo_term, MinimalTerm):
+            self.hpo_id = str(getattr(self.hpo_term, "identifier", ""))
+            self.hpo_label = getattr(self.hpo_term, "name", "")
 
-   # ------------------------------------------------------------------ #
-   # Mapping utilities
-   # ------------------------------------------------------------------ #
-   @staticmethod
-   def build_standard_bin_mapping(
-       *,
-       lower_extreme_term: MinimalTerm,
-       lower_term: MinimalTerm,
-       abnormal_term: MinimalTerm,
-       normal_term: Optional[MinimalTerm] = None,
-       upper_term: MinimalTerm,
-       upper_extreme_term: MinimalTerm,
-   ) -> dict[str, Optional[MinimalTerm]]:
-       """Return canonical percentile-bin-to-term mapping."""
-       return {
-           "below_3p": lower_extreme_term,
-           "between_3p_5p": lower_term,
-           "between_5p_10p": abnormal_term,
-           "between_10p_50p": normal_term,
-           "between_50p_90p": normal_term,
-           "between_90p_95p": abnormal_term,
-           "between_95p_97p": upper_term,
-           "above_97p": upper_extreme_term,
-       }
+    # ------------------------------------------------------------------ #
+    # Mapping utilities
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def build_standard_bin_mapping(
+        *,
+        lower_extreme_term: MinimalTerm,
+        lower_term: MinimalTerm,
+        abnormal_term: MinimalTerm,
+        normal_term: Optional[MinimalTerm] = None,
+        upper_term: MinimalTerm,
+        upper_extreme_term: MinimalTerm,
+    ) -> dict[str, Optional[MinimalTerm]]:
+        """Return canonical percentile-bin-to-term mapping."""
+        return {
+            "below_3p": lower_extreme_term,
+            "between_3p_5p": lower_term,
+            "between_5p_10p": abnormal_term,
+            "between_10p_50p": normal_term,
+            "between_50p_90p": normal_term,
+            "between_90p_95p": abnormal_term,
+            "between_95p_97p": upper_term,
+            "above_97p": upper_extreme_term,
+        }
 
-   # ------------------------------------------------------------------ #
-   # Factory constructor
-   # ------------------------------------------------------------------ #
-   @classmethod
-   def from_measurement_result(
-       cls,
-       measurement_result: MeasurementResult,
-       bin_to_term: dict,
-       gestational_age: GestationalAge,
-       *,
-       normal_bins: Optional[Set[str]] = None,
-       abnormal_term: Optional["MinimalTerm"] = None,
-   ) -> TermObservation:
-       """
-       Convert a MeasurementResult into a TermObservation.
+    # ------------------------------------------------------------------ #
+    # Factory constructor
+    # ------------------------------------------------------------------ #
+    @classmethod
+    def from_measurement_result(
+        cls,
+        measurement_result: MeasurementResult,
+        bin_to_term: dict,
+        gestational_age: GestationalAge,
+        *,
+        normal_bins: Optional[Set[str]] = None,
+        abnormal_term: Optional["MinimalTerm"] = None,
+    ) -> TermObservation:
+        """
+        Convert a MeasurementResult into a TermObservation.
 
-       This is the canonical bridge between numeric evaluation
-       and ontology interpretation, as used by PhenotypicExporter.
-       """
-       bin_key = measurement_result.bin_key
-       hpo_term = bin_to_term.get(bin_key)
+        This is the canonical bridge between numeric evaluation
+        and ontology interpretation, as used by PhenotypicExporter.
+        """
+        bin_key = measurement_result.bin_key
+        hpo_term = bin_to_term.get(bin_key)
 
-       if normal_bins and bin_key in normal_bins:
-           hpo_term = abnormal_term
-           observed = False
-       else:
-           observed = bool(hpo_term)
+        if normal_bins and bin_key in normal_bins:
+            hpo_term = abnormal_term
+            observed = False
+        else:
+            observed = bool(hpo_term)
 
-       return TermObservation(hpo_term=hpo_term, observed=observed, gestational_age=gestational_age)
+        return TermObservation(
+            hpo_term=hpo_term, observed=observed, gestational_age=gestational_age
+        )
 
-   # ------------------------------------------------------------------ #
-   # Serialization
-   # ------------------------------------------------------------------ #
-   def to_phenotypic_feature(self) -> typing.Dict[str, str]:
-       """Serialize to Phenopacket-compatible dictionary."""
-       ga_str = f"{self.gestational_age.weeks}w{self.gestational_age.days}d"
-       feature = {
-           "excluded": not self.observed,
-           "description": f"Measurement at {ga_str}",
-       }
-       if self.hpo_term:
-           feature["type"] = {"id": self.hpo_id, "label": self.hpo_label}
-       else:
-           feature["type"] = {"id": "HP:0000118", "label": "Phenotypic abnormality (unspecified)"}
-       if not self.observed:
-           feature["description"] = f"Measurement within normal range for gestational age ({ga_str})"
-       return feature
+    # ------------------------------------------------------------------ #
+    # Serialization
+    # ------------------------------------------------------------------ #
+    def to_phenotypic_feature(self) -> typing.Dict[str, str]:
+        """Serialize to Phenopacket-compatible dictionary."""
+        ga_str = f"{self.gestational_age.weeks}w{self.gestational_age.days}d"
+        feature = {
+            "excluded": not self.observed,
+            "description": f"Measurement at {ga_str}",
+        }
+        if self.hpo_term:
+            feature["type"] = {"id": self.hpo_id, "label": self.hpo_label}
+        else:
+            feature["type"] = {
+                "id": "HP:0000118",
+                "label": "Phenotypic abnormality (unspecified)",
+            }
+        if not self.observed:
+            feature["description"] = (
+                f"Measurement within normal range for gestational age ({ga_str})"
+            )
+        return feature
 
-   def __repr__(self) -> str:
-       label = self.hpo_label or "None"
-       return f"TermObservation(hpo_label='{label}', observed={self.observed}, ga={self.gestational_age.weeks}w{self.gestational_age.days}d)"
+    def __repr__(self) -> str:
+        label = self.hpo_label or "None"
+        return f"TermObservation(hpo_label='{label}', observed={self.observed}, ga={self.gestational_age.weeks}w{self.gestational_age.days}d)"

--- a/src/prenatalppkt/term_observation.py
+++ b/src/prenatalppkt/term_observation.py
@@ -1,85 +1,12 @@
 """
 term_observation.py
 
-Defines the `TermObservation` class -- the ontology-aware interpretation of a
+Defines `TermObservation`, the ontology-aware interpretation of a
 quantitative fetal sonographic measurement.
 
-Overview
---------
-This module bridges quantitative measurements (via `MeasurementResult`) with
-ontology terms (via `MinimalTerm` from hpotk).  It provides a consistent way to
-represent whether a given percentile-based result should be treated as an
-*observed abnormality* or an *excluded normal finding* in downstream analysis.
-
-Unlike earlier implementations, `TermObservation` does **not** assume any
-specific definition of "normal."  Instead, the calling application (or study
-configuration) must explicitly pass the set of percentile bins considered
-normal.  This decouples numeric logic from clinical semantics and allows
-population- or study-specific interpretations.
-
-Responsibilities
-----------------
-1. **Mapping construction**
- - Provides `build_standard_bin_mapping()` to generate a canonical mapping
-   between percentile bin keys (e.g., `"below_3p"`, `"between_90p_95p"`) and
-   ontology terms (`MinimalTerm` objects).
-
-2. **Observation derivation**
- - Converts a `MeasurementResult` into a `TermObservation` using
-   `from_measurement_result()`.
- - The caller supplies both the mapping and the definition of what percentile
-   bins are considered "normal".
-
-3. **Serialization**
- - Exports an ontology-aware measurement as a simple dictionary conforming to
-   Phenopacket JSON expectations via `to_phenotypic_feature()`.
-
-Design Principles
------------------
-- **No hard-coded normal ranges.**  The logic for what is "normal" is
-*injected* by the application, allowing different percentile thresholds for
-different populations, studies, or biometric parameters.
-
-- **Separation of concerns.**  Numeric percentile evaluation is handled by
-`MeasurementResult`; semantic interpretation (normal vs abnormal phenotype)
-lives here; and ontology term selection happens in higher-level mappings.
-
-Example
--------
-  from prenatalppkt.measurements.measurement_result import MeasurementResult
-  from prenatalppkt.term_observation import TermObservation
-
-  # Step 1: Define or load percentile bin mapping
-  mapping = TermObservation.build_standard_bin_mapping(
-      lower_extreme_term=microcephaly_term,
-      lower_term=decreased_head_circumference_term,
-      abnormal_term=abnormal_skull_term,
-      normal_term=normal_skull_term,
-      upper_term=increased_head_circumference_term,
-      upper_extreme_term=macrocephaly_term,
-  )
-
-  # Step 2: Define what bins count as "normal" for this analysis
-  normal_bins = {"between_10p_50p", "between_50p_90p"}
-
-  # Step 3: Convert a MeasurementResult to a TermObservation
-  result = reference_range.evaluate(value_mm)
-  obs = TermObservation.from_measurement_result(
-      measurement_result=result,
-      bin_to_term=mapping,
-      gestational_age=ga,
-      normal_bins=normal_bins,
-  )
-
-  # Step 4: Serialize for Phenopacket export
-  feature = obs.to_phenotypic_feature()
-
-Notes
------
-- The `normal_bins` argument provides full configurability.  If omitted, all
-bins with ontology terms are treated as "observed" (no normal range exclusion).
-- The `interpret_as_normal` flag can explicitly mark an observation as normal,
-even if percentile data are unavailable (e.g., clinician-reviewed cases).
+This version is fully aligned with the refactored exporter:
+- Always used as the final semantic representation (not mixed with raw results).
+- Clarified docstrings on its relationship to `PhenotypicExporter.evaluate_to_observation`.
 """
 
 from __future__ import annotations
@@ -93,154 +20,105 @@ from prenatalppkt.measurements.measurement_result import MeasurementResult
 
 @dataclass
 class TermObservation:
-    """
-    Represents an ontology-based interpretation of a MeasurementResult.
+   """
+   Represents an ontology-based interpretation of a MeasurementResult.
 
-    Attributes
-    ----------
-    hpo_term : Optional[MinimalTerm]
-        The ontology term representing the phenotype (e.g., "Microcephaly").
-    observed : bool
-        True if the abnormality was observed; False if explicitly not observed (normal finding / excluded).
-    gestational_age : GestationalAge
-        Gestational age context for the measurement.
-    parent_term : Optional[MinimalTerm]
-        Optional ontology parent term used for grouping or hierarchical context.
-    hpo_id, hpo_label : str
-        Convenience accessors automatically populated from `hpo_term`.
-    """
+   Attributes
+   ----------
+   hpo_term : Optional[MinimalTerm]
+       The ontology term representing the phenotype (e.g., "Microcephaly").
+   observed : bool
+       True if abnormality observed; False if excluded (normal finding).
+   gestational_age : GestationalAge
+       Context for interpretation.
+   """
 
-    hpo_term: Optional[MinimalTerm]
-    observed: bool
-    gestational_age: GestationalAge
-    parent_term: Optional[MinimalTerm] = None
-    hpo_id: str = ""
-    hpo_label: str = ""
+   hpo_term: Optional[MinimalTerm]
+   observed: bool
+   gestational_age: GestationalAge
+   parent_term: Optional[MinimalTerm] = None
+   hpo_id: str = ""
+   hpo_label: str = ""
 
-    def __post_init__(self) -> None:
-        """Populate identifier and label from MinimalTerm when available."""
-        if self.hpo_term and isinstance(self.hpo_term, MinimalTerm):
-            # MinimalTerm stores the ID as 'identifier', not 'term_id'
-            if hasattr(self.hpo_term, "identifier"):
-                self.hpo_id = str(self.hpo_term.identifier)
-            else:
-                self.hpo_id = ""
+   def __post_init__(self) -> None:
+       """Derive identifiers and labels from MinimalTerm."""
+       if self.hpo_term and isinstance(self.hpo_term, MinimalTerm):
+           self.hpo_id = str(getattr(self.hpo_term, "identifier", ""))
+           self.hpo_label = getattr(self.hpo_term, "name", "")
 
-            self.hpo_label = getattr(self.hpo_term, "name", "")
+   # ------------------------------------------------------------------ #
+   # Mapping utilities
+   # ------------------------------------------------------------------ #
+   @staticmethod
+   def build_standard_bin_mapping(
+       *,
+       lower_extreme_term: MinimalTerm,
+       lower_term: MinimalTerm,
+       abnormal_term: MinimalTerm,
+       normal_term: Optional[MinimalTerm] = None,
+       upper_term: MinimalTerm,
+       upper_extreme_term: MinimalTerm,
+   ) -> dict[str, Optional[MinimalTerm]]:
+       """Return canonical percentile-bin-to-term mapping."""
+       return {
+           "below_3p": lower_extreme_term,
+           "between_3p_5p": lower_term,
+           "between_5p_10p": abnormal_term,
+           "between_10p_50p": normal_term,
+           "between_50p_90p": normal_term,
+           "between_90p_95p": abnormal_term,
+           "between_95p_97p": upper_term,
+           "above_97p": upper_extreme_term,
+       }
 
-    # ------------------------------------------------------------------ #
-    # Mapping Builders
-    # ------------------------------------------------------------------ #
-    @staticmethod
-    def build_standard_bin_mapping(
-        *,
-        lower_extreme_term: MinimalTerm,
-        lower_term: MinimalTerm,
-        abnormal_term: MinimalTerm,
-        normal_term: Optional[MinimalTerm] = None,
-        upper_term: MinimalTerm,
-        upper_extreme_term: MinimalTerm,
-    ) -> dict[str, Optional[MinimalTerm]]:
-        """
-        Construct a canonical mapping from percentile bins to ontology terms.
+   # ------------------------------------------------------------------ #
+   # Factory constructor
+   # ------------------------------------------------------------------ #
+   @classmethod
+   def from_measurement_result(
+       cls,
+       measurement_result: MeasurementResult,
+       bin_to_term: dict,
+       gestational_age: GestationalAge,
+       *,
+       normal_bins: Optional[Set[str]] = None,
+       abnormal_term: Optional["MinimalTerm"] = None,
+   ) -> TermObservation:
+       """
+       Convert a MeasurementResult into a TermObservation.
 
-        Each key corresponds to a percentile interval defined by `MeasurementResult`. Values are `MinimalTerm` objects.
+       This is the canonical bridge between numeric evaluation
+       and ontology interpretation, as used by PhenotypicExporter.
+       """
+       bin_key = measurement_result.bin_key
+       hpo_term = bin_to_term.get(bin_key)
 
-        Returns
-        -------
-        dict[str, MinimalTerm]
-            Complete mapping ready for use in `from_measurement_result()`.
-        """
-        return {
-            "below_3p": lower_extreme_term,
-            "between_3p_5p": lower_term,
-            "between_5p_10p": abnormal_term,
-            "between_10p_50p": normal_term,
-            "between_50p_90p": normal_term,
-            "between_90p_95p": abnormal_term,
-            "between_95p_97p": upper_term,
-            "above_97p": upper_extreme_term,
-        }
+       if normal_bins and bin_key in normal_bins:
+           hpo_term = abnormal_term
+           observed = False
+       else:
+           observed = bool(hpo_term)
 
-    # ------------------------------------------------------------------ #
-    # Factory Constructor
-    # ------------------------------------------------------------------ #
-    @classmethod
-    def from_measurement_result(
-        cls,
-        measurement_result: MeasurementResult,
-        bin_to_term: dict,
-        gestational_age: GestationalAge,
-        *,
-        normal_bins: Optional[Set[str]] = None,
-        abnormal_term: Optional["MinimalTerm"] = None,
-    ) -> TermObservation:
-        """
-        Convert a MeasurementResult into a TermObservation using a bin->term mapping.
+       return TermObservation(hpo_term=hpo_term, observed=observed, gestational_age=gestational_age)
 
-        The caller can specify what percentile bins count as "normal".
+   # ------------------------------------------------------------------ #
+   # Serialization
+   # ------------------------------------------------------------------ #
+   def to_phenotypic_feature(self) -> typing.Dict[str, str]:
+       """Serialize to Phenopacket-compatible dictionary."""
+       ga_str = f"{self.gestational_age.weeks}w{self.gestational_age.days}d"
+       feature = {
+           "excluded": not self.observed,
+           "description": f"Measurement at {ga_str}",
+       }
+       if self.hpo_term:
+           feature["type"] = {"id": self.hpo_id, "label": self.hpo_label}
+       else:
+           feature["type"] = {"id": "HP:0000118", "label": "Phenotypic abnormality (unspecified)"}
+       if not self.observed:
+           feature["description"] = f"Measurement within normal range for gestational age ({ga_str})"
+       return feature
 
-        Parameters
-        ----------
-        measurement_result : MeasurementResult
-            The evaluated percentile bin.
-        bin_to_term : dict[str, MinimalTerm] | None
-            Mapping of percentile bins to ontology terms, typically produced by `build_standard_bin_mapping()`.
-        gestational_age : GestationalAge
-            Contextual gestational age of the measurement.
-
-        Returns
-        -------
-        TermObservation
-        """
-        bin_key = measurement_result.bin_key
-        hpo_term = bin_to_term.get(bin_key)
-
-        if normal_bins and bin_key in normal_bins:
-            # For normal bins -> use parent abnormal term, mark excluded
-            hpo_term = abnormal_term
-            observed = False
-        else:
-            observed = bool(hpo_term)
-
-        return TermObservation(
-            hpo_term=hpo_term, observed=observed, gestational_age=gestational_age
-        )
-
-    # ------------------------------------------------------------------ #
-    # Serialization
-    # ------------------------------------------------------------------ #
-    # def to_phenotypic_feature(self) -> dict:
-    #    """Serialize to a Phenopacket-style dictionary."""
-    #    if self.hpo_term is None:
-    #        return {"excluded": True, "description": "Measurement within normal range for gestational age", "description": f"Measurement within normal range for gestational age ({self.gestational_age.weeks}w{self.gestational_age.days}d)"}
-    #    return {"type": {"id": self.hpo_id, "label": self.hpo_label}, "excluded": not self.observed, "description": f"Measurement at {self.gestational_age.weeks}w{self.gestational_age.days}d"}
-
-    def to_phenotypic_feature(self) -> typing.Dict[str, str]:
-        """Serialize to a Phenopacket-style dictionary."""
-        ga_str = f"{self.gestational_age.weeks}w{self.gestational_age.days}d"
-
-        feature = {
-            "excluded": not self.observed,
-            "description": f"Measurement at {ga_str}",
-        }
-
-        # Always include a 'type' field, even if no HPO term is available
-        if self.hpo_term:
-            feature["type"] = {"id": self.hpo_id, "label": self.hpo_label}
-        else:
-            feature["type"] = {
-                "id": "HP:0000118",
-                "label": "Phenotypic abnormality (unspecified)",
-            }
-        # Always add normal-range text if excluded (normal finding)
-        if not self.observed:
-            feature["description"] = (
-                f"Measurement within normal range for gestational age ({ga_str})"
-            )
-
-        return feature
-
-    def __repr__(self) -> str:
-        label = self.hpo_label or "None"
-        return f"TermObservation(hpo_label='{label}', observed={self.observed}, ga={self.gestational_age.weeks}w{self.gestational_age.days}d)"
+   def __repr__(self) -> str:
+       label = self.hpo_label or "None"
+       return f"TermObservation(hpo_label='{label}', observed={self.observed}, ga={self.gestational_age.weeks}w{self.gestational_age.days}d)"

--- a/tests/test_phenotypic_export.py
+++ b/tests/test_phenotypic_export.py
@@ -1,19 +1,17 @@
 """
 tests/test_phenotypic_export.py
 
-Comprehensive test suite for PhenotypicExporter.
-
-Ensures correct:
-- YAML-based HPO term mapping
-- Normal vs abnormal logic (observed/excluded)
-- Custom normal bin overrides
-- Batch and JSON export
-- Compatibility with INTERGROWTH and NICHD sources
-- Initialization and error-handling behavior
+Key design principles:
+- Tests validate that YAML mappings are correctly applied
+- No hardcoded HPO terms (except in YAML validation tests)
+- Changes to biometry_hpo_mappings.yaml don't break tests
+- Tests focus on the mapping logic, not specific term choices
 """
 
 import json
 import pytest
+import yaml
+from pathlib import Path
 from prenatalppkt.phenotypic_export import PhenotypicExporter
 from prenatalppkt.term_observation import TermObservation
 
@@ -33,18 +31,98 @@ def nichd_exporter():
     return PhenotypicExporter(source="nichd")
 
 
+@pytest.fixture(scope="module")
+def test_ga():
+    """Use GA=14.0w - well-covered in INTERGROWTH reference data."""
+    return 14.0
+
+
+@pytest.fixture(scope="module")
+def yaml_mappings():
+    """Load the YAML mappings file for validation."""
+    yaml_path = (
+        Path(__file__).parent.parent
+        / "data"
+        / "mappings"
+        / "biometry_hpo_mappings.yaml"
+    )
+    with open(yaml_path) as f:
+        return yaml.safe_load(f)
+
+
 # ---------------------------------------------------------------------- #
-# INITIALIZATION + BASIC SANITY CHECKS
+# HELPER FUNCTIONS
+# ---------------------------------------------------------------------- #
+
+
+def get_feature(exporter, measurement_type, value, ga=14.0, **kwargs):
+    """Convenience wrapper: evaluate -> serialize."""
+    obs = exporter.evaluate_to_observation(
+        measurement_type=measurement_type,
+        value_mm=value,
+        gestational_age_weeks=ga,
+        **kwargs,
+    )
+    assert isinstance(obs, TermObservation), "Must return TermObservation"
+    return obs.to_phenotypic_feature()
+
+
+def get_reference_values(exporter, measurement_type, ga):
+    """Extract actual percentile thresholds from reference data.
+
+    Returns dict with keys like "3rd", "5th", "10th", "50th", "90th", "95th", "97th"
+    (WITHOUT "Percentile" suffix in INTERGROWTH data)
+    """
+    df = exporter.reference.tables[measurement_type]["ct"]
+    row = df.loc[df["Gestational Age (weeks)"].round(1) == round(ga, 1)]
+    if row.empty:
+        raise ValueError(f"No reference data for {measurement_type} at GA={ga}w")
+
+    # Get all percentile columns using case-insensitive check
+    exclude_cols = {
+        "Gestational Age (weeks)",
+        "Measure",
+        "Race",
+        "SourceFile",
+        "ParseTimestamp",
+    }
+    percentile_cols = [
+        c for c in df.columns if c not in exclude_cols and "percentile" in c.lower()
+    ]
+
+    result = row[percentile_cols].iloc[0].to_dict()
+
+    # Normalize keys: remove " Percentile" suffix if present for consistency
+    normalized = {}
+    for k, v in result.items():
+        normalized_key = k.replace(" Percentile", "")
+        normalized[normalized_key] = v
+
+    return normalized
+
+
+def get_expected_hpo(yaml_mappings, measurement_type, bin_key):
+    """Get expected HPO term for a measurement type and bin from YAML."""
+    mtype_config = yaml_mappings[measurement_type]
+    bin_config = mtype_config["bins"].get(bin_key)
+
+    if bin_config is None:
+        return None
+
+    return {"id": bin_config["id"], "label": bin_config["label"]}
+
+
+# ---------------------------------------------------------------------- #
+# INITIALIZATION TESTS
 # ---------------------------------------------------------------------- #
 
 
 def test_exporter_initialization(intergrowth_exporter):
-    """Exporter initializes with proper reference tables and mappings."""
+    """Verify proper initialization with reference tables and YAML mappings."""
     assert intergrowth_exporter.source == "intergrowth"
     assert hasattr(intergrowth_exporter, "reference")
     assert hasattr(intergrowth_exporter, "mappings")
-    assert isinstance(intergrowth_exporter.mappings, dict)
-    # Check at least the five core measurement types are present
+
     expected_keys = {
         "head_circumference",
         "biparietal_diameter",
@@ -53,219 +131,229 @@ def test_exporter_initialization(intergrowth_exporter):
         "occipitofrontal_diameter",
     }
     assert expected_keys.issubset(intergrowth_exporter.mappings.keys())
-    # Reference tables must include these too
     assert all(k in intergrowth_exporter.reference.tables for k in expected_keys)
 
 
 def test_invalid_source_raises_error():
-    """Invalid exporter source should raise a ValueError."""
-    with pytest.raises(ValueError):
-        PhenotypicExporter(source="invalid_source_name")
+    """Invalid source should raise ValueError during initialization."""
+    with pytest.raises(ValueError, match="Unsupported source"):
+        PhenotypicExporter(source="invalid_source")
+
+
+def test_mappings_structure(intergrowth_exporter):
+    """Validate YAML mapping structure for all measurements."""
+    for config in intergrowth_exporter.mappings.values():
+        assert "bins" in config
+        assert "normal_bins" in config
+        assert "abnormal_term" in config
+        assert isinstance(config["normal_bins"], set)
+        assert "between_10p_50p" in config["normal_bins"]
+        assert "between_50p_90p" in config["normal_bins"]
 
 
 def test_fractional_gestational_age(intergrowth_exporter):
-    """Fractional gestational ages (e.g. 14.3w) should round correctly to reference table rows."""
-    f = intergrowth_exporter.evaluate_to_observation(
-        "head_circumference", 100.0, 14.3
-    ).to_phenotypic_feature()
-    assert "14w" in f["description"]
-    assert "type" in f and "label" in f["type"]
-
-
-def test_batch_export_handles_errors(intergrowth_exporter):
-    """Batch export should continue processing after an invalid measurement."""
-    measurements = [
-        {
-            "measurement_type": "head_circumference",
-            "value_mm": 85.0,
-            "gestational_age_weeks": 14.0,
-        },
-        {
-            "measurement_type": "nonexistent_type",
-            "value_mm": 25.0,
-            "gestational_age_weeks": 14.0,
-        },
-        {
-            "measurement_type": "femur_length",
-            "value_mm": 7.0,
-            "gestational_age_weeks": 14.0,
-        },
-    ]
-    result = intergrowth_exporter.batch_export(measurements)
-    assert len(result) == 3
-    assert "error" in result[1]
-    assert "type" in result[0] and "type" in result[2]
-
-
-def test_all_core_measurements_supported(intergrowth_exporter):
-    """Ensure every core measurement type in YAML can be evaluated without crash."""
-    for mtype in intergrowth_exporter.mappings.keys():
-        obs = intergrowth_exporter.evaluate_to_observation(mtype, 100.0, 14.0)
-        f = obs.to_phenotypic_feature()
-        assert isinstance(f, dict)
-        assert "excluded" in f
-
-
-# ---------------------------------------------------------------------- #
-# HELPER
-# ---------------------------------------------------------------------- #
-
-
-def get_feature(exporter, measurement_type, value, ga=14.0, **kwargs):
-    """Convenience wrapper to obtain serialized feature."""
-    obs = exporter.evaluate_to_observation(
-        measurement_type=measurement_type,
-        value_mm=value,
-        gestational_age_weeks=ga,
-        **kwargs,
-    )
-    assert isinstance(obs, TermObservation)
-    return obs.to_phenotypic_feature()
-
-
-# ---------------------------------------------------------------------- #
-# HEAD CIRCUMFERENCE (HC)
-# ---------------------------------------------------------------------- #
-
-
-def test_hc_lower_extreme_microcephaly(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "head_circumference", 85.0)
-    assert f["type"]["id"] == "HP:0000252"
-    assert f["type"]["label"] == "Microcephaly"
-    assert f["excluded"] is False
-
-
-def test_hc_lower_decreased_head_circumference(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "head_circumference", 88.0)
-    assert f["type"]["label"] == "Decreased head circumference"
-    assert f["excluded"] is False
-
-
-def test_hc_normal_excluded(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "head_circumference", 100.0)
-    assert f["excluded"] is True
-    assert "normal range" in f["description"]
-
-
-def test_hc_upper_increased_head_circumference(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "head_circumference", 115.0)
-    assert f["type"]["label"] == "Increased head circumference"
-    assert f["excluded"] is False
-
-
-def test_hc_upper_extreme_macrocephaly(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "head_circumference", 120.0)
-    assert f["type"]["label"] == "Macrocephaly"
-    assert f["excluded"] is False
-
-
-# ---------------------------------------------------------------------- #
-# BIPARIETAL DIAMETER (BPD)
-# ---------------------------------------------------------------------- #
-
-
-def test_bpd_lower_extreme_secondary_microcephaly(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "biparietal_diameter", 20.0)
-    assert f["type"]["label"] == "Secondary microcephaly"
-    assert f["excluded"] is False
-
-
-def test_bpd_abnormal_skull_size(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "biparietal_diameter", 23.0)
-    assert f["type"]["label"] == "Abnormality of skull size"
-    assert f["excluded"] is False
-
-
-def test_bpd_upper_postnatal_macrocephaly(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "biparietal_diameter", 45.0)
-    assert f["type"]["label"] == "Postnatal macrocephaly"
-    assert f["excluded"] is False
-
-
-def test_bpd_normal_excluded(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "biparietal_diameter", 28.0)
-    assert f["excluded"] is True
-
-
-# ---------------------------------------------------------------------- #
-# FEMUR LENGTH (FL)
-# ---------------------------------------------------------------------- #
-
-
-def test_fl_lower_extreme_short_fetal_femur(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "femur_length", 5.0)
-    assert f["type"]["label"] == "Short fetal femur length"
-    assert f["excluded"] is False
-
-
-def test_fl_lower_short_femur(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "femur_length", 6.0)
-    assert f["type"]["label"] == "Short femur"
-    assert f["excluded"] is False
-
-
-def test_fl_abnormal_morphology(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "femur_length", 7.0)
-    assert f["type"]["label"] == "Abnormal femur morphology"
-    assert f["excluded"] is False
-
-
-def test_fl_normal_excluded(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "femur_length", 8.0)
-    assert f["excluded"] is True
-
-
-# ---------------------------------------------------------------------- #
-# ABDOMINAL CIRCUMFERENCE (AC)
-# ---------------------------------------------------------------------- #
-
-
-def test_ac_lower_extreme_small_abdomen(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "abdominal_circumference", 60.0)
-    assert f["type"]["label"] == "Small fetal abdominal circumference"
-    assert f["excluded"] is False
-
-
-def test_ac_abnormal_gi_morphology(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "abdominal_circumference", 65.0)
-    assert f["type"]["label"] == "Abnormal fetal gastrointestinal system morphology"
-    assert f["excluded"] is False
-
-
-def test_ac_normal_excluded(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "abdominal_circumference", 90.0)
-    assert f["excluded"] is True
-
-
-# ---------------------------------------------------------------------- #
-# OCCIPITOFRONTAL DIAMETER (OFD)
-# ---------------------------------------------------------------------- #
-
-
-def test_ofd_abnormal_skull(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "occipitofrontal_diameter", 25.0)
-    assert f["type"]["label"] == "Abnormality of skull size"
-    assert f["excluded"] is False
-
-
-def test_ofd_normal_excluded(intergrowth_exporter):
-    f = get_feature(intergrowth_exporter, "occipitofrontal_diameter", 35.0)
-    assert f["excluded"] is True
-
-
-# ---------------------------------------------------------------------- #
-# NORMAL BIN OVERRIDE
-# ---------------------------------------------------------------------- #
-
-
-def test_custom_normal_bins_override(intergrowth_exporter):
-    """User-defined normal bins should override defaults."""
-    custom_bins = {"between_5p_10p"}  # treat 5-10th percentile as normal
+    """Fractional GA should round to nearest reference table row."""
     obs = intergrowth_exporter.evaluate_to_observation(
-        "head_circumference", 90.0, 14.0, normal_bins=custom_bins
+        "head_circumference", 100.0, 14.3
     )
     f = obs.to_phenotypic_feature()
-    assert f["excluded"] is True  # normally abnormal, now excluded
+    assert "14w" in f["description"]
+    assert "type" in f
+
+
+# ---------------------------------------------------------------------- #
+# YAML-DRIVEN BIN MAPPING TESTS
+# ---------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "measurement_type",
+    [
+        "head_circumference",
+        "biparietal_diameter",
+        "femur_length",
+        "abdominal_circumference",
+        "occipitofrontal_diameter",
+    ],
+)
+def test_below_3p_maps_correctly(
+    intergrowth_exporter, yaml_mappings, measurement_type, test_ga
+):
+    """Values below 3rd percentile should map to YAML-defined term for below_3p bin."""
+    refs = get_reference_values(intergrowth_exporter, measurement_type, test_ga)
+    value = refs["3rd"] - 1.0  # Below 3rd percentile
+
+    expected_hpo = get_expected_hpo(yaml_mappings, measurement_type, "below_3p")
+
+    f = get_feature(intergrowth_exporter, measurement_type, value, test_ga)
+
+    if expected_hpo is None:
+        # If YAML maps to null, should show abnormal_term with excluded=False
+        abnormal_term = yaml_mappings[measurement_type]["abnormal_term"]
+        assert f["type"]["id"] == abnormal_term["id"]
+        assert f["excluded"] is False
+    else:
+        assert f["type"]["id"] == expected_hpo["id"]
+        assert f["type"]["label"] == expected_hpo["label"]
+        assert f["excluded"] is False
+
+
+@pytest.mark.parametrize(
+    "measurement_type",
+    [
+        "head_circumference",
+        "biparietal_diameter",
+        "femur_length",
+        "abdominal_circumference",
+        "occipitofrontal_diameter",
+    ],
+)
+def test_between_3p_5p_maps_correctly(
+    intergrowth_exporter, yaml_mappings, measurement_type, test_ga
+):
+    """Values between 3rd-5th percentile should map to YAML-defined term."""
+    refs = get_reference_values(intergrowth_exporter, measurement_type, test_ga)
+    value = (refs["3rd"] + refs["5th"]) / 2
+
+    expected_hpo = get_expected_hpo(yaml_mappings, measurement_type, "between_3p_5p")
+
+    f = get_feature(intergrowth_exporter, measurement_type, value, test_ga)
+
+    if expected_hpo is None:
+        # If YAML maps to null for this bin, result depends on normal_bins config
+        normal_bins = yaml_mappings[measurement_type]["normal_bins"]
+        if "between_3p_5p" in normal_bins:
+            assert f["excluded"] is True
+        else:
+            abnormal_term = yaml_mappings[measurement_type]["abnormal_term"]
+            assert f["type"]["id"] == abnormal_term["id"]
+            assert f["excluded"] is False
+    else:
+        assert f["type"]["id"] == expected_hpo["id"]
+        assert f["type"]["label"] == expected_hpo["label"]
+        assert f["excluded"] is False
+
+
+@pytest.mark.parametrize(
+    "measurement_type",
+    [
+        "head_circumference",
+        "biparietal_diameter",
+        "femur_length",
+        "abdominal_circumference",
+        "occipitofrontal_diameter",
+    ],
+)
+def test_normal_range_excluded(
+    intergrowth_exporter, yaml_mappings, measurement_type, test_ga
+):
+    """Values in 10th-90th percentile should be excluded (normal)."""
+    refs = get_reference_values(intergrowth_exporter, measurement_type, test_ga)
+    value = refs["50th"]  # Dead center of normal range
+
+    f = get_feature(intergrowth_exporter, measurement_type, value, test_ga)
+    assert f["excluded"] is True
+    assert "normal range" in f["description"].lower()
+
+
+@pytest.mark.parametrize(
+    "measurement_type",
+    [
+        "head_circumference",
+        "biparietal_diameter",
+        "femur_length",
+        "abdominal_circumference",
+        "occipitofrontal_diameter",
+    ],
+)
+def test_above_97p_maps_correctly(
+    intergrowth_exporter, yaml_mappings, measurement_type, test_ga
+):
+    """>97th percentile should map to YAML-defined term for above_97p bin."""
+    refs = get_reference_values(intergrowth_exporter, measurement_type, test_ga)
+    value = refs["97th"] + 1.0
+
+    expected_hpo = get_expected_hpo(yaml_mappings, measurement_type, "above_97p")
+
+    f = get_feature(intergrowth_exporter, measurement_type, value, test_ga)
+
+    if expected_hpo is None:
+        # If YAML maps to null, should show abnormal_term with excluded=False
+        abnormal_term = yaml_mappings[measurement_type]["abnormal_term"]
+        assert f["type"]["id"] == abnormal_term["id"]
+        assert f["excluded"] is False
+    else:
+        assert f["type"]["id"] == expected_hpo["id"]
+        assert f["type"]["label"] == expected_hpo["label"]
+        assert f["excluded"] is False
+
+
+# ---------------------------------------------------------------------- #
+# SPECIFIC BIN VALIDATION (HEAD CIRCUMFERENCE EXAMPLE)
+# ---------------------------------------------------------------------- #
+
+
+def test_hc_all_bins_match_yaml(intergrowth_exporter, yaml_mappings, test_ga):
+    """Comprehensive validation that all HC bins map to correct YAML terms."""
+    refs = get_reference_values(intergrowth_exporter, "head_circumference", test_ga)
+
+    # Test each bin with appropriate value
+    bin_test_values = {
+        "below_3p": refs["3rd"] - 1.0,
+        "between_3p_5p": (refs["3rd"] + refs["5th"]) / 2,
+        "between_5p_10p": (refs["5th"] + refs["10th"]) / 2,
+        "between_10p_50p": refs["50th"] - 5.0,
+        "between_50p_90p": refs["50th"] + 5.0,
+        "between_90p_95p": (refs["90th"] + refs["95th"]) / 2,
+        "between_95p_97p": (refs["95th"] + refs["97th"]) / 2,
+        "above_97p": refs["97th"] + 1.0,
+    }
+
+    yaml_hc = yaml_mappings["head_circumference"]
+    normal_bins = yaml_hc["normal_bins"]
+
+    for bin_key, test_value in bin_test_values.items():
+        f = get_feature(intergrowth_exporter, "head_circumference", test_value, test_ga)
+        expected_hpo = yaml_hc["bins"].get(bin_key)
+
+        if bin_key in normal_bins:
+            # Should be excluded (normal)
+            assert f["excluded"] is True, f"Bin {bin_key} should be excluded"
+        elif expected_hpo is None:
+            # Null mapping → uses abnormal_term
+            assert f["type"]["id"] == yaml_hc["abnormal_term"]["id"]
+            assert f["excluded"] is False
+        else:
+            # Specific HPO term from YAML
+            assert f["type"]["id"] == expected_hpo["id"]
+            assert f["type"]["label"] == expected_hpo["label"]
+            assert f["excluded"] is False
+
+
+# ---------------------------------------------------------------------- #
+# CUSTOM NORMAL BIN OVERRIDE
+# ---------------------------------------------------------------------- #
+
+
+def test_custom_normal_bins_override(intergrowth_exporter, test_ga):
+    """Custom normal_bins should override default exclusion logic."""
+    refs = get_reference_values(intergrowth_exporter, "head_circumference", test_ga)
+    value = (refs["5th"] + refs["10th"]) / 2
+
+    # Without override: abnormal (observed=True)
+    f1 = get_feature(intergrowth_exporter, "head_circumference", value, test_ga)
+    assert f1["excluded"] is False
+
+    # With override: treat 5-10p as normal
+    custom_bins = {"between_5p_10p", "between_10p_50p", "between_50p_90p"}
+    f2 = get_feature(
+        intergrowth_exporter,
+        "head_circumference",
+        value,
+        test_ga,
+        normal_bins=custom_bins,
+    )
+    assert f2["excluded"] is True
 
 
 # ---------------------------------------------------------------------- #
@@ -273,52 +361,108 @@ def test_custom_normal_bins_override(intergrowth_exporter):
 # ---------------------------------------------------------------------- #
 
 
-def test_batch_export_multiple(intergrowth_exporter):
+def test_batch_export_multiple(intergrowth_exporter, yaml_mappings, test_ga):
     """Batch export should process multiple measurements successfully."""
+    refs_hc = get_reference_values(intergrowth_exporter, "head_circumference", test_ga)
+    refs_fl = get_reference_values(intergrowth_exporter, "femur_length", test_ga)
+
     measurements = [
         {
             "measurement_type": "head_circumference",
-            "value_mm": 85.0,
-            "gestational_age_weeks": 14.0,
+            "value_mm": refs_hc["3rd"] - 1.0,
+            "gestational_age_weeks": test_ga,
         },
         {
             "measurement_type": "femur_length",
-            "value_mm": 5.0,
-            "gestational_age_weeks": 14.0,
+            "value_mm": refs_fl["3rd"] - 0.5,
+            "gestational_age_weeks": test_ga,
         },
         {
             "measurement_type": "biparietal_diameter",
-            "value_mm": 20.0,
-            "gestational_age_weeks": 14.0,
+            "value_mm": 28.0,  # Likely normal at GA=14w
+            "gestational_age_weeks": test_ga,
         },
     ]
-    result = intergrowth_exporter.batch_export(measurements)
-    assert isinstance(result, list)
-    assert len(result) == 3
-    labels = [r["type"]["label"] for r in result if "type" in r]
-    assert "Microcephaly" in labels
-    assert "Short fetal femur length" in labels
+
+    results = intergrowth_exporter.batch_export(measurements)
+    assert len(results) == 3
+
+    # Verify results match YAML expectations
+    expected_hc = get_expected_hpo(yaml_mappings, "head_circumference", "below_3p")
+    expected_fl = get_expected_hpo(yaml_mappings, "femur_length", "below_3p")
+
+    assert results[0]["type"]["id"] == expected_hc["id"]
+    assert results[1]["type"]["id"] == expected_fl["id"]
+    assert "excluded" in results[2]
 
 
-def test_to_json_export(intergrowth_exporter):
-    """JSON export should yield valid and parseable JSON string."""
+def test_batch_export_handles_errors(intergrowth_exporter, test_ga):
+    """Batch export should continue after encountering invalid measurement."""
     measurements = [
         {
             "measurement_type": "head_circumference",
-            "value_mm": 120.0,
-            "gestational_age_weeks": 14.0,
+            "value_mm": 100.0,
+            "gestational_age_weeks": test_ga,
+        },
+        {
+            "measurement_type": "nonexistent_type",
+            "value_mm": 25.0,
+            "gestational_age_weeks": test_ga,
         },
         {
             "measurement_type": "femur_length",
-            "value_mm": 8.0,
-            "gestational_age_weeks": 14.0,
+            "value_mm": 10.0,
+            "gestational_age_weeks": test_ga,
         },
     ]
+
+    results = intergrowth_exporter.batch_export(measurements)
+    assert len(results) == 3
+    assert "error" in results[1]
+    assert "type" in results[0] and "type" in results[2]
+
+
+def test_to_json_export(intergrowth_exporter, yaml_mappings, test_ga):
+    """JSON export should produce valid, parseable JSON string."""
+    refs_hc = get_reference_values(intergrowth_exporter, "head_circumference", test_ga)
+    refs_fl = get_reference_values(intergrowth_exporter, "femur_length", test_ga)
+
+    measurements = [
+        {
+            "measurement_type": "head_circumference",
+            "value_mm": refs_hc["97th"] + 1.0,
+            "gestational_age_weeks": test_ga,
+        },
+        {
+            "measurement_type": "femur_length",
+            "value_mm": refs_fl["50th"],
+            "gestational_age_weeks": test_ga,
+        },
+    ]
+
     json_str = intergrowth_exporter.to_json(measurements)
     parsed = json.loads(json_str)
     assert isinstance(parsed, list)
-    assert parsed[0]["type"]["label"] == "Macrocephaly"
+
+    # Verify JSON output matches YAML expectations
+    expected_hc = get_expected_hpo(yaml_mappings, "head_circumference", "above_97p")
+    assert parsed[0]["type"]["id"] == expected_hc["id"]
     assert parsed[1]["excluded"] is True
+
+
+def test_json_export_pretty_formatting(intergrowth_exporter, test_ga):
+    """JSON export with pretty=True should be indented."""
+    measurements = [
+        {
+            "measurement_type": "head_circumference",
+            "value_mm": 100.0,
+            "gestational_age_weeks": test_ga,
+        }
+    ]
+
+    json_str = intergrowth_exporter.to_json(measurements, pretty=True)
+    assert "\n" in json_str
+    assert "  " in json_str  # Indentation
 
 
 # ---------------------------------------------------------------------- #
@@ -326,11 +470,34 @@ def test_to_json_export(intergrowth_exporter):
 # ---------------------------------------------------------------------- #
 
 
-def test_nichd_reference_data(nichd_exporter):
-    """Ensure NICHD reference operates similarly for supported measurements."""
-    f = get_feature(nichd_exporter, "head_circumference", 85.0)
-    assert f["type"]["label"] in {"Microcephaly", "Abnormality of skull size"}
-    assert "14w" in f["description"]
+def test_nichd_reference_data(nichd_exporter, yaml_mappings):
+    """NICHD exporter should operate similarly to INTERGROWTH."""
+    # Use GA well-covered in NICHD data (e.g., 20w)
+    ga = 20.0
+    refs = get_reference_values(nichd_exporter, "head_circumference", ga)
+    value = refs["3rd"] - 1.0
+
+    expected_hpo = get_expected_hpo(yaml_mappings, "head_circumference", "below_3p")
+
+    f = get_feature(nichd_exporter, "head_circumference", value, ga)
+    assert f["excluded"] is False
+    assert f["type"]["id"] == expected_hpo["id"]
+    assert "20w" in f["description"]
+
+
+def test_nichd_consistency_with_intergrowth(nichd_exporter, yaml_mappings):
+    """NICHD and INTERGROWTH should use same mapping logic."""
+    ga = 20.0
+
+    # Get NICHD reference
+    refs_nichd = get_reference_values(nichd_exporter, "femur_length", ga)
+    value = refs_nichd["3rd"] - 0.5
+
+    expected_hpo = get_expected_hpo(yaml_mappings, "femur_length", "below_3p")
+
+    f_nichd = get_feature(nichd_exporter, "femur_length", value, ga)
+    assert f_nichd["type"]["id"] == expected_hpo["id"]
+    assert f_nichd["excluded"] is False
 
 
 # ---------------------------------------------------------------------- #
@@ -338,11 +505,97 @@ def test_nichd_reference_data(nichd_exporter):
 # ---------------------------------------------------------------------- #
 
 
-def test_invalid_measurement_raises(intergrowth_exporter):
-    with pytest.raises(ValueError):
+def test_invalid_measurement_type_raises(intergrowth_exporter):
+    """Unregistered measurement type should raise ValueError."""
+    with pytest.raises(ValueError, match="not available"):
         intergrowth_exporter.evaluate_to_observation("unknown_measurement", 25.0, 14.0)
 
 
 def test_invalid_ga_raises(intergrowth_exporter):
-    with pytest.raises(ValueError):
+    """GA outside reference range should raise ValueError."""
+    with pytest.raises(ValueError, match="No reference data"):
         intergrowth_exporter.evaluate_to_observation("head_circumference", 90.0, 2.0)
+
+
+def test_missing_measurement_in_registry_raises(intergrowth_exporter):
+    """Measurement type not in SonographicMeasurement.registry should raise KeyError."""
+    # This would only happen if YAML has a type not backed by a subclass
+    with pytest.raises((KeyError, ValueError)):
+        intergrowth_exporter.evaluate_to_observation(
+            "hypothetical_unregistered_type", 100.0, 14.0
+        )
+
+
+# ---------------------------------------------------------------------- #
+# REGISTRY INTEGRATION TESTS
+# ---------------------------------------------------------------------- #
+
+
+def test_registry_based_dispatch(intergrowth_exporter):
+    """Verify registry-based polymorphism works for all measurement types."""
+    from prenatalppkt.sonographic_measurement import SonographicMeasurement
+
+    for mtype in intergrowth_exporter.mappings:
+        assert mtype in SonographicMeasurement.registry, (
+            f"{mtype} missing from SonographicMeasurement registry"
+        )
+
+        # Instantiate and verify it has evaluate method
+        cls = SonographicMeasurement.registry[mtype]
+        instance = cls()
+        assert hasattr(instance, "evaluate")
+
+
+def test_evaluate_returns_measurement_result(intergrowth_exporter, test_ga):
+    """Subclass.evaluate() must return MeasurementResult (not TermObservation)."""
+    from prenatalppkt.measurements.measurement_result import MeasurementResult
+    from prenatalppkt.sonographic_measurement import SonographicMeasurement
+    from prenatalppkt.measurements.reference_range import ReferenceRange
+    from prenatalppkt.gestational_age import GestationalAge
+
+    refs = get_reference_values(intergrowth_exporter, "head_circumference", test_ga)
+    ga = GestationalAge.from_weeks(test_ga)
+    ref_range = ReferenceRange(ga, list(refs.values()))
+
+    cls = SonographicMeasurement.registry["head_circumference"]
+    instance = cls()
+    result = instance.evaluate(ga, refs["50th"], ref_range)
+
+    assert isinstance(result, MeasurementResult), (
+        "Subclass.evaluate() must return MeasurementResult"
+    )
+
+
+# ---------------------------------------------------------------------- #
+# SEPARATION OF CONCERNS
+# ---------------------------------------------------------------------- #
+
+
+def test_evaluate_vs_export_separation(intergrowth_exporter, test_ga):
+    """evaluate_to_observation returns TermObservation; export_feature returns dict."""
+    obs = intergrowth_exporter.evaluate_to_observation(
+        "head_circumference", 100.0, test_ga
+    )
+    assert isinstance(obs, TermObservation)
+
+    feature_dict = intergrowth_exporter.export_feature(
+        "head_circumference", 100.0, test_ga
+    )
+    assert isinstance(feature_dict, dict)
+    assert "type" in feature_dict
+    assert "excluded" in feature_dict
+
+
+def test_all_measurements_supported(intergrowth_exporter):
+    """Every measurement in YAML should be evaluatable without crashes."""
+    test_ga = 14.0
+    for mtype in intergrowth_exporter.mappings:
+        obs = None
+        try:
+            obs = intergrowth_exporter.evaluate_to_observation(mtype, 100.0, test_ga)
+        except ValueError:
+            # Some measurements might not have data at GA=14w, that's OK
+            continue
+        f = obs.to_phenotypic_feature()
+        assert isinstance(f, dict)
+        assert "excluded" in f


### PR DESCRIPTION
Refactors phenotypic export and measurement evaluation to use proper OOP patterns. Implements automatic subclass registration via `SonographicMeasurement`, enforces consistent `TermObservation` return types, and separates evaluation from serialization.