### PR TITLE
Add support for parsing the 'impression' sub-key within fetus entries from Observer

### DIFF
--- a/src/prenatalppkt/dto/observer/builders/fetus_anatomy_data.py
+++ b/src/prenatalppkt/dto/observer/builders/fetus_anatomy_data.py
@@ -7,6 +7,7 @@ Anatomy findings and clinical impressions grouping.
 from dataclasses import dataclass
 from typing import Any, List, Optional
 from prenatalppkt.hpo.simple_term import SimpleTerm
+from prenatalppkt.dto.observer.fetuses.fetus_impression_data import FetusImpressionData
 
 
 @dataclass
@@ -24,7 +25,7 @@ class FetusAnatomyData:
     hpo_terms: List[SimpleTerm]
     anatomy_text: Optional[str] = None
     anatomy: Optional[Any] = None
-    impression: Optional[Any] = None
+    impression: Optional[FetusImpressionData] = None
 
     def __repr__(self) -> str:
         return (

--- a/src/prenatalppkt/dto/observer/fetuses/__init__.py
+++ b/src/prenatalppkt/dto/observer/fetuses/__init__.py
@@ -8,5 +8,12 @@ from .fetus_core_data import FetusCoreData
 from .measurements_data import MeasurementsData
 from .ratios_data import FetusRatiosData
 from .efw_data import FetusEfwData
+from .fetus_impression_data import FetusImpressionData
 
-__all__ = ["FetusCoreData", "MeasurementsData", "FetusRatiosData", "FetusEfwData"]
+__all__ = [
+    "FetusCoreData",
+    "MeasurementsData",
+    "FetusRatiosData",
+    "FetusEfwData",
+    "FetusImpressionData",
+]

--- a/src/prenatalppkt/dto/observer/fetuses/fetus_impression_data.py
+++ b/src/prenatalppkt/dto/observer/fetuses/fetus_impression_data.py
@@ -1,0 +1,57 @@
+"""
+src/prenatalppkt/dto/observer/fetuses/fetus_impression_data.py
+
+DTO for fetus impression(s) extracted from Observer JSON.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Any, Dict
+
+
+@dataclass
+class FetusImpressionData:
+    """
+    Data class representing impression information attached to a fetus entry.
+
+    Attributes:
+        fetus_number: optional numeric fetus identifier
+        impression_text: raw impression string when a single string is present
+        impressions: list of impression items when it's structured as a list
+        fetus_anomalies: list of anomaly dictionaries
+        other: any other impression-related data
+    """
+
+    fetus_number: Optional[int] = None
+    impression_text: Optional[str] = None
+    impressions: Optional[List[str]] = None
+    fetus_anomalies: Optional[List[Dict[str, Any]]] = None
+    other: Optional[Dict[str, Any]] = None
+
+    @property
+    def is_present(self) -> bool:
+        """Return True if any impression content is present."""
+        return bool(
+            self.impression_text
+            or (self.impressions and len(self.impressions) > 0)
+            or self.fetus_anomalies
+            or self.other
+        )
+
+    def __repr__(self) -> str:
+        return f"FetusImpressionData(fetus_number={self.fetus_number}, present={self.is_present})"
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "FetusImpressionData":
+        """
+        Create FetusImpressionData from a dictionary.
+
+        Args:
+            d: Dictionary containing impression data
+
+        Returns:
+            FetusImpressionData instance
+        """
+        return cls(
+            fetus_anomalies=d.get("fetus_anomalies"),
+            other={k: v for k, v in d.items() if k not in {"fetus_anomalies"}},
+        )

--- a/src/prenatalppkt/parser/observer/fetuses/__init__.py
+++ b/src/prenatalppkt/parser/observer/fetuses/__init__.py
@@ -3,6 +3,7 @@ from .fetuses_fetus_parser import FetusFetusParser
 from .fetuses_measurements_parser import FetusMeasurementsParser
 from .fetuses_ratios_parser import FetusRatiosParser
 from .fetuses_efw_parser import FetusEfwParser
+from .fetuses_impression_parser import FetusImpressionParser
 
 __all__ = [
     "FetusAnatomyTextParser",
@@ -10,4 +11,5 @@ __all__ = [
     "FetusMeasurementsParser",
     "FetusRatiosParser",
     "FetusEfwParser",
+    "FetusImpressionParser",
 ]

--- a/src/prenatalppkt/parser/observer/fetuses/fetuses_impression_parser.py
+++ b/src/prenatalppkt/parser/observer/fetuses/fetuses_impression_parser.py
@@ -1,0 +1,67 @@
+"""
+src/prenatalppkt/parser/observer/fetuses/fetuses_impression_parser.py
+
+Parser for the 'impression' section within a fetus JSON object.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from prenatalppkt.dto.observer.fetuses.fetus_impression_data import FetusImpressionData
+
+logger = logging.getLogger(__name__)
+
+
+class FetusImpressionParser:
+    """Parse the 'impression' subkey at the fetus level from Observer JSON."""
+
+    def parse(self, json_data: Dict[str, Any]) -> Optional[FetusImpressionData]:
+        """
+        Parse impression content out of a fetus-level mapping.
+
+        Args:
+            json_data: a dict representing a fetus entry from Observer JSON
+
+        Returns:
+            FetusImpressionData when impression content is present, otherwise None.
+        """
+        if not isinstance(json_data, dict):
+            raise ValueError(
+                f"malformed argument, expecting `dict` but got {type(json_data)}"
+            )
+
+        impression = json_data.get("impression")
+        if not impression:
+            logger.info("No 'impression' key found in fetus JSON")
+            return None
+
+        fetus_number = None
+        fetus_meta = json_data.get("fetus")
+        if isinstance(fetus_meta, dict):
+            fetus_number = fetus_meta.get("fetus_number")
+
+        # If impression is a single string, normalize and return
+        if isinstance(impression, str):
+            text = impression.strip()
+            if not text:
+                return None
+            return FetusImpressionData(fetus_number=fetus_number, impression_text=text)
+
+        # If impression is a list, filter and return as list
+        if isinstance(impression, list):
+            items = [str(i).strip() for i in impression if str(i).strip()]
+            if not items:
+                return None
+            return FetusImpressionData(fetus_number=fetus_number, impressions=items)
+
+        # Fallback: coerce to string if possible
+        try:
+            text = str(impression).strip()
+            if text:
+                return FetusImpressionData(
+                    fetus_number=fetus_number, impression_text=text
+                )
+        except Exception:
+            logger.warning("Unable to coerce 'impression' to string: %r", impression)
+
+        return None

--- a/tests/parser/observer/fetuses/test_fetus_impression_parser.py
+++ b/tests/parser/observer/fetuses/test_fetus_impression_parser.py
@@ -1,0 +1,69 @@
+"""Unit tests for FetusImpressionParser."""
+
+from prenatalppkt.parser.observer.fetuses import FetusImpressionParser
+from prenatalppkt.dto.observer.fetuses.fetus_impression_data import FetusImpressionData
+
+
+def test_parse_impression_as_string():
+    """Test parsing impression when it's a simple string."""
+    parser = FetusImpressionParser()
+    input_json = {"impression": "Normal anatomy scan"}
+    result = parser.parse(input_json)
+
+    assert isinstance(result, FetusImpressionData)
+    assert result.impression_text == "Normal anatomy scan"
+    assert result.is_present
+
+
+def test_parse_impression_as_list():
+    """Test parsing impression when it's a list of strings."""
+    parser = FetusImpressionParser()
+    input_json = {"impression": ["Finding 1", "Finding 2", "Finding 3"]}
+    result = parser.parse(input_json)
+
+    assert isinstance(result, FetusImpressionData)
+    assert result.impressions == ["Finding 1", "Finding 2", "Finding 3"]
+    assert len(result.impressions) == 3
+    assert result.is_present
+
+
+def test_parse_impression_with_fetus_number():
+    """Test that fetus_number is extracted when available."""
+    parser = FetusImpressionParser()
+    input_json = {"fetus": {"fetus_number": 1}, "impression": "Normal findings"}
+    result = parser.parse(input_json)
+
+    assert isinstance(result, FetusImpressionData)
+    assert result.fetus_number == 1
+    assert result.impression_text == "Normal findings"
+
+
+def test_parse_missing_impression():
+    """Test that None is returned when impression key is missing."""
+    parser = FetusImpressionParser()
+    result = parser.parse({})
+    assert result is None
+
+
+def test_parse_empty_string_impression():
+    """Test that None is returned for empty string impression."""
+    parser = FetusImpressionParser()
+    result = parser.parse({"impression": ""})
+    assert result is None
+
+
+def test_parse_empty_list_impression():
+    """Test that None is returned for empty list impression."""
+    parser = FetusImpressionParser()
+    result = parser.parse({"impression": []})
+    assert result is None
+
+
+def test_parse_malformed_input():
+    """Test that ValueError is raised for non-dict input."""
+    parser = FetusImpressionParser()
+    try:
+        parser.parse("not a dict")
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "malformed argument" in str(e)


### PR DESCRIPTION
Implements parsing and DTO support for the `impression` sub-key within individual fetus entries from Observer JSON. This continues the pattern of creating atomic DTOs for each sub-key under `fetuses[i]`.