### PR TITLE
feat(observer): multi-fetus extraction support

### DIFF
--- a/src/prenatalppkt/etl/extractors/observer.py
+++ b/src/prenatalppkt/etl/extractors/observer.py
@@ -42,6 +42,17 @@ def _validate_structure(data: Any) -> List[Dict[str, Any]]:
     return fetuses
 
 
+def _validate_fetus_count(fetuses: List[Dict[str, Any]], declared_count: Any) -> None:
+    """Warn (do not raise) if exam.fetus_count disagrees with len(fetuses)."""
+    actual = len(fetuses)
+    if declared_count is not None and declared_count != actual:
+        logger.warning(
+            "exam.fetus_count=%s but %d fetuses present in array",
+            declared_count,
+            actual,
+        )
+
+
 def _extract_one_fetus(
     fetus_data: Dict[str, Any], factory: TermBinFactory
 ) -> List[TermBin]:

--- a/src/prenatalppkt/etl/extractors/observer.py
+++ b/src/prenatalppkt/etl/extractors/observer.py
@@ -159,6 +159,15 @@ def extract_from_file(filepath: Path, factory: TermBinFactory = None) -> List[Te
     return extract(data, factory)
 
 
+def extract_all_fetuses_from_file(
+    filepath: Path, factory: TermBinFactory | None = None
+) -> Dict[int, List[TermBin]]:
+    """Multi-fetus equivalent of `extract_from_file`."""
+    with open(filepath, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return extract_all_fetuses(data, factory)
+
+
 def _get_fetus_number(fetus_data: Dict[str, Any]) -> int:
     """Extract fetus number from fetus data."""
     fetus_section = fetus_data.get("fetus", {})

--- a/src/prenatalppkt/etl/extractors/observer.py
+++ b/src/prenatalppkt/etl/extractors/observer.py
@@ -96,6 +96,53 @@ def extract(data: dict, factory: TermBinFactory | None = None) -> list[TermBin]:
     return term_bins
 
 
+def extract_all_fetuses(
+    data: dict, factory: TermBinFactory | None = None
+) -> Dict[int, List[TermBin]]:
+    """
+    Extract biometry from every fetus in an Observer JSON.
+
+    Per-fetus extraction errors (e.g. missing biometry on a T1-only twin) are
+    logged and surface as an empty list for that `fetus_number` key, rather
+    than aborting the whole extraction. Top-level structural errors still
+    raise.
+
+    Args:
+        data: Parsed Observer JSON dictionary
+        factory: TermBinFactory instance (uses module singleton if None)
+
+    Returns:
+        Dict keyed by `fetus_number`; values are lists of TermBins for that
+        fetus (empty list when extraction failed for that fetus).
+
+    Raises:
+        ValueError: If the JSON structure itself is malformed (missing
+            `fetuses` key, wrong type, empty list).
+    """
+    if factory is None:
+        factory = _default_factory
+
+    logger.debug("Starting Observer JSON extraction (multi-fetus)")
+    fetuses = _validate_structure(data)
+    _validate_fetus_count(fetuses, data.get("exam", {}).get("fetus_count"))
+
+    result: Dict[int, List[TermBin]] = {}
+    for fetus_data in fetuses:
+        fetus_number = _get_fetus_number(fetus_data)
+        try:
+            result[fetus_number] = _extract_one_fetus(fetus_data, factory)
+        except ValueError as e:
+            logger.warning("Fetus %d skipped: %s", fetus_number, e)
+            result[fetus_number] = []
+
+    logger.info(
+        "Extracted %d total TermBins across %d fetuses",
+        sum(len(tbs) for tbs in result.values()),
+        len(result),
+    )
+    return result
+
+
 def extract_from_file(filepath: Path, factory: TermBinFactory = None) -> List[TermBin]:
     """
     Extract biometry measurements from Observer JSON file.

--- a/src/prenatalppkt/etl/extractors/observer.py
+++ b/src/prenatalppkt/etl/extractors/observer.py
@@ -30,6 +30,18 @@ logging.basicConfig(level=logging.DEBUG)
 _default_factory = TermBinFactory()
 
 
+def _validate_structure(data: Any) -> List[Dict[str, Any]]:
+    """Raise on top-level structural issues; return the fetuses list."""
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected dict, got {type(data)}")
+    if "fetuses" not in data:
+        raise ValueError("Missing 'fetuses' key in Observer JSON")
+    fetuses = data["fetuses"]
+    if not fetuses or not isinstance(fetuses, list):
+        raise ValueError("'fetuses' must be non-empty list")
+    return fetuses
+
+
 def extract(data: dict, factory: TermBinFactory | None = None) -> list[TermBin]:
     """
     Extract biometry measurements from Observer JSON and convert to TermBins.
@@ -49,16 +61,7 @@ def extract(data: dict, factory: TermBinFactory | None = None) -> list[TermBin]:
 
     logger.debug("Starting Observer JSON extraction")
 
-    # Validate structure
-    if not isinstance(data, dict):
-        raise ValueError(f"Expected dict, got {type(data)}")
-
-    if "fetuses" not in data:
-        raise ValueError("Missing 'fetuses' key in Observer JSON")
-
-    fetuses = data["fetuses"]
-    if not fetuses or not isinstance(fetuses, list):
-        raise ValueError("'fetuses' must be non-empty list")
+    fetuses = _validate_structure(data)
 
     # Extract from first fetus (can extend for multiple fetuses)
     fetus_data = fetuses[0]

--- a/src/prenatalppkt/etl/extractors/observer.py
+++ b/src/prenatalppkt/etl/extractors/observer.py
@@ -70,8 +70,16 @@ def extract(data: dict, factory: TermBinFactory | None = None) -> list[TermBin]:
     if factory is None:
         factory = _default_factory  # <-- reuse, no reload
 
-    logger.debug("Starting Observer JSON extraction")
+    logger.debug("Starting Observer JSON extraction (single-fetus)")
     fetuses = _validate_structure(data)
+
+    if len(fetuses) > 1:
+        logger.warning(
+            "Observer JSON has %d fetuses; extract() returns only the first. "
+            "Use extract_all_fetuses() for multi-fetus support.",
+            len(fetuses),
+        )
+
     term_bins = _extract_one_fetus(fetuses[0], factory)
     logger.info(f"Extracted {len(term_bins)} TermBins from Observer JSON")
     return term_bins

--- a/src/prenatalppkt/etl/extractors/observer.py
+++ b/src/prenatalppkt/etl/extractors/observer.py
@@ -42,6 +42,17 @@ def _validate_structure(data: Any) -> List[Dict[str, Any]]:
     return fetuses
 
 
+def _extract_one_fetus(
+    fetus_data: Dict[str, Any], factory: TermBinFactory
+) -> List[TermBin]:
+    """Extract TermBins from one fetus dict; raises if required biometry missing."""
+    fetus_number = _get_fetus_number(fetus_data)
+    logger.debug(f"Processing fetus {fetus_number}")
+    term_bins = _parse_measurements(fetus_data, fetus_number, factory)
+    validate_required_measurements(term_bins)
+    return term_bins
+
+
 def extract(data: dict, factory: TermBinFactory | None = None) -> list[TermBin]:
     """
     Extract biometry measurements from Observer JSON and convert to TermBins.
@@ -60,21 +71,8 @@ def extract(data: dict, factory: TermBinFactory | None = None) -> list[TermBin]:
         factory = _default_factory  # <-- reuse, no reload
 
     logger.debug("Starting Observer JSON extraction")
-
     fetuses = _validate_structure(data)
-
-    # Extract from first fetus (can extend for multiple fetuses)
-    fetus_data = fetuses[0]
-    fetus_number = _get_fetus_number(fetus_data)
-
-    logger.debug(f"Processing fetus {fetus_number}")
-
-    # Parse measurements into TermBins
-    term_bins = _parse_measurements(fetus_data, fetus_number, factory)
-
-    # Validate required measurements present
-    validate_required_measurements(term_bins)
-
+    term_bins = _extract_one_fetus(fetuses[0], factory)
     logger.info(f"Extracted {len(term_bins)} TermBins from Observer JSON")
     return term_bins
 

--- a/tests/etl/extractors/test_observer_multifetus.py
+++ b/tests/etl/extractors/test_observer_multifetus.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 
 from prenatalppkt.etl.extractors import observer
@@ -142,3 +143,19 @@ def test_extract_all_fetuses_discordant_twins(caplog):
     assert len(result[1]) == 4
     assert result[2] == []
     assert any("Fetus 2 skipped" in record.message for record in caplog.records)
+
+
+def test_extract_all_fetuses_from_file(tmp_path):
+    """File-loading variant parses JSON and delegates to extract_all_fetuses."""
+    data = {
+        "exam": {"fetus_count": 2},
+        "fetuses": [_fetus_with_full_biometry(1), _fetus_with_full_biometry(2)],
+    }
+    test_file = tmp_path / "twins.json"
+    test_file.write_text(json.dumps(data))
+
+    result = observer.extract_all_fetuses_from_file(test_file)
+
+    assert set(result.keys()) == {1, 2}
+    assert len(result[1]) == 4
+    assert len(result[2]) == 4

--- a/tests/etl/extractors/test_observer_multifetus.py
+++ b/tests/etl/extractors/test_observer_multifetus.py
@@ -87,3 +87,58 @@ def test_validate_fetus_count_silent_when_no_declared_count(caplog):
         observer._validate_fetus_count(fetuses, declared_count=None)
 
     assert not any("fetus_count" in record.message for record in caplog.records)
+
+
+def test_extract_all_fetuses_singleton():
+    """Singleton case returns a dict with one key."""
+    data = {"exam": {"fetus_count": 1}, "fetuses": [_fetus_with_full_biometry(1)]}
+
+    result = observer.extract_all_fetuses(data)
+
+    assert set(result.keys()) == {1}
+    assert len(result[1]) == 4
+
+
+def test_extract_all_fetuses_twins():
+    """Twins case returns a dict keyed by both fetus_numbers."""
+    data = {
+        "exam": {"fetus_count": 2},
+        "fetuses": [_fetus_with_full_biometry(1), _fetus_with_full_biometry(2)],
+    }
+
+    result = observer.extract_all_fetuses(data)
+
+    assert set(result.keys()) == {1, 2}
+    assert len(result[1]) == 4
+    assert len(result[2]) == 4
+
+
+def test_extract_all_fetuses_discordant_twins(caplog):
+    """If one twin is missing biometry, its slot is empty but the other survives."""
+    data = {
+        "exam": {"fetus_count": 2},
+        "fetuses": [
+            _fetus_with_full_biometry(1),
+            {
+                "fetus": {"fetus_number": 2},
+                "measurements": [
+                    {
+                        "label": "CRL",
+                        "value": 5.5,
+                        "unit_of_measure": "cm",
+                        "calculated_percentile": 50.0,
+                    }
+                ],
+            },
+        ],
+    }
+
+    with caplog.at_level(
+        logging.WARNING, logger="prenatalppkt.etl.extractors.observer"
+    ):
+        result = observer.extract_all_fetuses(data)
+
+    assert set(result.keys()) == {1, 2}
+    assert len(result[1]) == 4
+    assert result[2] == []
+    assert any("Fetus 2 skipped" in record.message for record in caplog.records)

--- a/tests/etl/extractors/test_observer_multifetus.py
+++ b/tests/etl/extractors/test_observer_multifetus.py
@@ -51,3 +51,39 @@ def test_extract_warns_when_multiple_fetuses_present(caplog):
     assert len(term_bins) == 4
     assert any("2 fetuses" in record.message for record in caplog.records)
     assert any("extract_all_fetuses" in record.message for record in caplog.records)
+
+
+def test_validate_fetus_count_warns_on_mismatch(caplog):
+    """_validate_fetus_count logs a warning when declared count != len(fetuses)."""
+    fetuses = [_fetus_with_full_biometry(1), _fetus_with_full_biometry(2)]
+
+    with caplog.at_level(
+        logging.WARNING, logger="prenatalppkt.etl.extractors.observer"
+    ):
+        observer._validate_fetus_count(fetuses, declared_count=3)
+
+    assert any("fetus_count=3" in record.message for record in caplog.records)
+
+
+def test_validate_fetus_count_silent_on_match(caplog):
+    """_validate_fetus_count emits no warning when declared count matches."""
+    fetuses = [_fetus_with_full_biometry(1)]
+
+    with caplog.at_level(
+        logging.WARNING, logger="prenatalppkt.etl.extractors.observer"
+    ):
+        observer._validate_fetus_count(fetuses, declared_count=1)
+
+    assert not any("fetus_count" in record.message for record in caplog.records)
+
+
+def test_validate_fetus_count_silent_when_no_declared_count(caplog):
+    """_validate_fetus_count emits no warning when declared count is None."""
+    fetuses = [_fetus_with_full_biometry(1), _fetus_with_full_biometry(2)]
+
+    with caplog.at_level(
+        logging.WARNING, logger="prenatalppkt.etl.extractors.observer"
+    ):
+        observer._validate_fetus_count(fetuses, declared_count=None)
+
+    assert not any("fetus_count" in record.message for record in caplog.records)

--- a/tests/etl/extractors/test_observer_multifetus.py
+++ b/tests/etl/extractors/test_observer_multifetus.py
@@ -1,0 +1,53 @@
+"""Tests for multi-fetus handling in the Observer JSON extractor."""
+
+from __future__ import annotations
+
+import logging
+
+from prenatalppkt.etl.extractors import observer
+
+
+def _fetus_with_full_biometry(fetus_number: int) -> dict:
+    return {
+        "fetus": {"fetus_number": fetus_number},
+        "measurements": [
+            {
+                "label": "HC",
+                "value": 17.5,
+                "unit_of_measure": "cm",
+                "calculated_percentile": 50.0,
+            },
+            {
+                "label": "BPD",
+                "value": 6.8,
+                "unit_of_measure": "cm",
+                "calculated_percentile": 55.0,
+            },
+            {
+                "label": "AC",
+                "value": 21.2,
+                "unit_of_measure": "cm",
+                "calculated_percentile": 48.0,
+            },
+            {
+                "label": "Femur",
+                "value": 4.8,
+                "unit_of_measure": "cm",
+                "calculated_percentile": 52.0,
+            },
+        ],
+    }
+
+
+def test_extract_warns_when_multiple_fetuses_present(caplog):
+    """extract() returns only the first fetus's TermBins but warns about the rest."""
+    data = {"fetuses": [_fetus_with_full_biometry(1), _fetus_with_full_biometry(2)]}
+
+    with caplog.at_level(
+        logging.WARNING, logger="prenatalppkt.etl.extractors.observer"
+    ):
+        term_bins = observer.extract(data)
+
+    assert len(term_bins) == 4
+    assert any("2 fetuses" in record.message for record in caplog.records)
+    assert any("extract_all_fetuses" in record.message for record in caplog.records)


### PR DESCRIPTION
Adds ```extract_all_fetuses()``` returning ```dict[fetus_number, list[TermBin]]``` for twin/triplet support. ```extract()``` still works. First part of #38 