### PR TITLE
Vj/scan type detection

### DIFF
--- a/src/prenatalppkt/etl/extractors/observer.py
+++ b/src/prenatalppkt/etl/extractors/observer.py
@@ -11,6 +11,11 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from prenatalppkt.etl.constants import OBSERVER_NAME_MAP
+from prenatalppkt.etl.scan_type import (
+    ScanType,
+    UnsupportedScanTypeError,
+    detect_scan_type,
+)
 from prenatalppkt.etl.term_bin_factory import (
     TermBinFactory,
     validate_required_measurements,
@@ -89,6 +94,18 @@ def extract(data: dict, factory: TermBinFactory | None = None) -> list[TermBin]:
             "Observer JSON has %d fetuses; extract() returns only the first. "
             "Use extract_all_fetuses() for multi-fetus support.",
             len(fetuses),
+        )
+
+    # Classify the scan up front so callers get a typed error for shapes the
+    # T2/T3 biometry path can't handle (first-trimester, partial, or unrecognised).
+    scan_type = detect_scan_type(data)
+    if scan_type is ScanType.FIRST_TRIMESTER:
+        raise UnsupportedScanTypeError(
+            "First trimester scan (CRL/NT only); T2/T3 ETL path required"
+        )
+    if scan_type is ScanType.UNKNOWN:
+        raise UnsupportedScanTypeError(
+            "Unrecognised scan type; missing the full HC/BPD/AC/Femur biometry set"
         )
 
     term_bins = _extract_one_fetus(fetuses[0], factory)

--- a/src/prenatalppkt/etl/scan_type.py
+++ b/src/prenatalppkt/etl/scan_type.py
@@ -1,0 +1,62 @@
+"""Scan-type classifier for Observer JSON exports.
+
+Today the cerebro pipeline detects first-trimester scans via its own
+`_is_first_trimester()` helper and skips them; the prenatalppkt extractor
+just raises a generic ValueError when biometry is missing. Lifting the
+classifier into the library lets every caller (cerebro CLI, future TUI,
+Beacon endpoint) reach the same verdict from the same code path.
+
+The enum is deliberately minimal: only the distinctions the extractor
+acts on today (FIRST_TRIMESTER vs T2_T3_BIOMETRY) plus UNKNOWN for
+partial / malformed inputs. ANATOMY_SURVEY vs GROWTH_SCAN splits stay
+deferred until a code path needs them.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+T1_LABELS = frozenset({"CRL", "NT"})
+T2T3_REQUIRED_LABELS = frozenset({"AC", "BPD", "HC", "Femur"})
+
+
+class ScanType(Enum):
+    """Routing classifier for the ETL pipeline."""
+
+    FIRST_TRIMESTER = "first_trimester"
+    T2_T3_BIOMETRY = "t2_t3_biometry"
+    UNKNOWN = "unknown"
+
+
+class UnsupportedScanTypeError(ValueError):
+    """Raised when the scan type is detectable but no ETL path exists for it.
+
+    Subclasses ValueError so existing `except ValueError` callers keep working.
+    """
+
+
+def detect_scan_type(observer_json: dict[str, Any]) -> ScanType:
+    """Classify an Observer JSON dict by inspecting the first fetus's labels.
+
+    Rules:
+      - Has CRL or NT and lacks the full T2/T3 set -> FIRST_TRIMESTER
+      - Has all of {AC, BPD, HC, Femur}             -> T2_T3_BIOMETRY
+      - Otherwise                                   -> UNKNOWN
+    """
+    fetuses = observer_json.get("fetuses") or []
+    if not fetuses:
+        return ScanType.UNKNOWN
+    measurements = fetuses[0].get("measurements") or []
+    labels = {m.get("label") or m.get("name") for m in measurements}
+    labels.discard(None)
+
+    has_t2t3 = T2T3_REQUIRED_LABELS.issubset(labels)
+    if has_t2t3:
+        return ScanType.T2_T3_BIOMETRY
+
+    has_t1 = bool(labels & T1_LABELS)
+    if has_t1:
+        return ScanType.FIRST_TRIMESTER
+
+    return ScanType.UNKNOWN

--- a/tests/etl/extractors/test_observer.py
+++ b/tests/etl/extractors/test_observer.py
@@ -144,7 +144,7 @@ class TestObserverExtract:
             ]
         }
 
-        with pytest.raises(ValueError, match="Missing required biometry measurements"):
+        with pytest.raises(ValueError, match="Unrecognised scan type"):
             observer.extract(data)
 
     def test_extract_skips_measurements_without_percentile(self):

--- a/tests/etl/test_scan_type.py
+++ b/tests/etl/test_scan_type.py
@@ -1,0 +1,103 @@
+"""Tests for ScanType classifier + UnsupportedScanTypeError."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from prenatalppkt.etl.scan_type import (
+    ScanType,
+    UnsupportedScanTypeError,
+    detect_scan_type,
+)
+
+DATA_DIR = Path("tests/data")
+
+
+def _fetus(labels: list[str]) -> dict:
+    """Build a minimal Observer JSON dict with one fetus carrying the given labels."""
+    return {
+        "fetuses": [
+            {
+                "fetus": {"fetus_number": 1},
+                "measurements": [{"label": lbl} for lbl in labels],
+            }
+        ]
+    }
+
+
+class TestDetectScanType:
+    def test_full_biometry_is_t2_t3(self):
+        assert (
+            detect_scan_type(_fetus(["AC", "BPD", "HC", "Femur"]))
+            == ScanType.T2_T3_BIOMETRY
+        )
+
+    def test_full_biometry_plus_extras_is_t2_t3(self):
+        """Extra labels (Nuchal Fold, Humerus, etc.) don't change the classification."""
+        assert (
+            detect_scan_type(_fetus(["AC", "BPD", "HC", "Femur", "Nuchal Fold", "OFD"]))
+            == ScanType.T2_T3_BIOMETRY
+        )
+
+    def test_crl_only_is_first_trimester(self):
+        assert detect_scan_type(_fetus(["CRL"])) == ScanType.FIRST_TRIMESTER
+
+    def test_nt_only_is_first_trimester(self):
+        assert detect_scan_type(_fetus(["NT"])) == ScanType.FIRST_TRIMESTER
+
+    def test_crl_and_nt_is_first_trimester(self):
+        assert detect_scan_type(_fetus(["CRL", "NT"])) == ScanType.FIRST_TRIMESTER
+
+    def test_partial_biometry_is_unknown(self):
+        """HC alone (no T1 marker, no full T2/T3 set) is UNKNOWN."""
+        assert detect_scan_type(_fetus(["HC"])) == ScanType.UNKNOWN
+
+    def test_empty_measurements_is_unknown(self):
+        assert detect_scan_type(_fetus([])) == ScanType.UNKNOWN
+
+    def test_missing_fetuses_key_is_unknown(self):
+        assert detect_scan_type({}) == ScanType.UNKNOWN
+
+    def test_empty_fetuses_list_is_unknown(self):
+        assert detect_scan_type({"fetuses": []}) == ScanType.UNKNOWN
+
+    def test_accepts_name_field_alias(self):
+        """Some exports use 'name' instead of 'label'. Both should classify the same."""
+        data = {
+            "fetuses": [
+                {"measurements": [{"name": n} for n in ["AC", "BPD", "HC", "Femur"]]}
+            ]
+        }
+        assert detect_scan_type(data) == ScanType.T2_T3_BIOMETRY
+
+
+class TestUnsupportedScanTypeError:
+    def test_is_value_error_subclass(self):
+        """`except ValueError` should keep catching this for legacy callers."""
+        assert issubclass(UnsupportedScanTypeError, ValueError)
+        with pytest.raises(ValueError):
+            raise UnsupportedScanTypeError("test")
+
+
+class TestCorpus:
+    """Each shipped fixture maps to a known ScanType - encodes the workflow shape."""
+
+    EXPECTED: ClassVar[dict[str, ScanType]] = {
+        "Apple_Sally_pretty.json": ScanType.T2_T3_BIOMETRY,
+        "Blue_Sally_pretty.json": ScanType.T2_T3_BIOMETRY,
+        "Charm_Sally_pretty.json": ScanType.T2_T3_BIOMETRY,
+        "Eclair_Sally_pretty.json": ScanType.T2_T3_BIOMETRY,
+        "Diva_Sally_pretty.json": ScanType.FIRST_TRIMESTER,
+    }
+
+    @pytest.mark.parametrize("fixture_name", sorted(EXPECTED.keys()))
+    def test_corpus_classification(self, fixture_name):
+        fixture = DATA_DIR / fixture_name
+        if not fixture.exists():
+            pytest.skip(f"{fixture_name} not found")
+        data = json.loads(fixture.read_text(encoding="utf-8"))
+        assert detect_scan_type(data) == self.EXPECTED[fixture_name]


### PR DESCRIPTION
add ScanType enum + UnsupportedScanTypeError (#56)

Work towards fixing the parsing of `Diva_Sally_pretty.json`

Also lays the groundwork for Issue #59 - the HPO trimester-onset terms (HP:0034199 Late first trimester onset, HP:0034198 Second trimester onset, HP:0034197 Third trimester onset)