### PR TITLE
Vj/stable subject

### DIFF
--- a/src/prenatalppkt/builders/observer_phenopacket.py
+++ b/src/prenatalppkt/builders/observer_phenopacket.py
@@ -110,7 +110,10 @@ def _phenopacket_id(accession_id: Optional[str], fetus_number: int) -> str:
 
 def _subject_id(accession_id: Optional[str], fetus_number: int) -> str:
     if accession_id:
-        patient = accession_id.lower().replace("_", "-").split("-", 1)[0]
+        parts = accession_id.lower().replace("_", "-").split("-")
+        patient = parts[0]
+        if len(parts) > 2:
+            return f"{patient}-preg{parts[2]}-fetus-{fetus_number}"
         return f"{patient}-fetus-{fetus_number}"
     return f"fetus-{fetus_number}"
 
@@ -167,7 +170,7 @@ def build_observer_phenopacket(
         pp = pps2.Phenopacket(
             id=_phenopacket_id(accession_id, fetus_number),
             subject=pps2.Individual(
-                id=f"fetus-{fetus_number}",
+                id=_subject_id(accession_id, fetus_number),
                 time_at_last_encounter=pps2.TimeElement(
                     gestational_age=pps2.GestationalAge(
                         weeks=subject_ga.weeks, days=subject_ga.days

--- a/src/prenatalppkt/builders/observer_phenopacket.py
+++ b/src/prenatalppkt/builders/observer_phenopacket.py
@@ -109,6 +109,11 @@ def _phenopacket_id(accession_id: Optional[str], fetus_number: int) -> str:
 
 
 def _subject_id(accession_id: Optional[str], fetus_number: int) -> str:
+    # TODO(@VarenyaJ): this accession-segment split is reverse-engineered
+    # from Columbia/CUIMC Observer exports only (confirmed via Derek's
+    # 2026-07-13 email). We have no real Observer samples from Broad,
+    # Charite, or UNSW - confirm this shape holds there before trusting
+    # subject.id grouping on non-CUIMC data.
     if accession_id:
         parts = accession_id.lower().replace("_", "-").split("-")
         patient = parts[0]
@@ -146,6 +151,13 @@ def build_observer_phenopacket(
     impression = parse_clinical_impression(data, "observer_json", hpo_cr=hpo_cr)
     anatomy = parse_fetal_anatomy(data, "observer_json", hpo_cr=hpo_cr)
     parse_estimated_fetal_weight(data, "observer_json")  # Plan 2 hook
+    # TODO(@VarenyaJ): #90a Measurement enrichment (deferred 2026-07-13) -
+    # emitting Measurement is unblocked, but turning an abnormal reading
+    # into a PhenotypicFeature needs a percentile/z-score threshold from
+    # Ron/Michael/Peter, and TermBin only stores a binned PercentileRange
+    # (not the raw percentile) while phenopackets' ReferenceRange expects
+    # low/high in the same unit as the value (mm) - percentile-as-a-
+    # ReferenceRange doesn't map cleanly yet either.
 
     hp_resource = _hpo_resource(hpo_parser)
     impression_terms = impression.get("hpo_terms", [])

--- a/src/prenatalppkt/builders/observer_phenopacket.py
+++ b/src/prenatalppkt/builders/observer_phenopacket.py
@@ -108,6 +108,13 @@ def _phenopacket_id(accession_id: Optional[str], fetus_number: int) -> str:
     return f"fetus-{fetus_number}"
 
 
+def _subject_id(accession_id: Optional[str], fetus_number: int) -> str:
+    if accession_id:
+        patient = accession_id.lower().replace("_", "-").split("-", 1)[0]
+        return f"{patient}-fetus-{fetus_number}"
+    return f"fetus-{fetus_number}"
+
+
 def build_observer_phenopacket(
     data: dict,
     hpo_parser: HpoParser,

--- a/tests/builders/test_observer_phenopacket.py
+++ b/tests/builders/test_observer_phenopacket.py
@@ -112,11 +112,11 @@ def test_accession_id_prefixes_phenopacket_id(hpo_parser, now_ts):
     data = _exam([_fetus_full_biometry(1)])
 
     pps = build_observer_phenopacket(
-        data, hpo_parser, now_ts, accession_id="A184594_U_1_1"
+        data, hpo_parser, now_ts, accession_id="A000001_U_1_1"
     )
 
-    assert pps[0].id == "a184594-u-1-1-fetus-1"
-    assert pps[0].subject.id == "fetus-1"
+    assert pps[0].id == "a000001-u-1-1-fetus-1"
+    assert pps[0].subject.id == "a000001-preg1-fetus-1"
 
 
 def test_twin_returns_two_phenopackets(hpo_parser, now_ts):
@@ -125,7 +125,7 @@ def test_twin_returns_two_phenopackets(hpo_parser, now_ts):
     pps = build_observer_phenopacket(data, hpo_parser, now_ts, accession_id="TWIN")
 
     assert len(pps) == 2
-    assert [pp.subject.id for pp in pps] == ["fetus-1", "fetus-2"]
+    assert [pp.subject.id for pp in pps] == ["twin-fetus-1", "twin-fetus-2"]
     assert [pp.id for pp in pps] == ["twin-fetus-1", "twin-fetus-2"]
     # Twin 2 is T1 - should carry CRL-derived bins
     twin2_descriptions = [pf.description for pf in pps[1].phenotypic_features]
@@ -160,7 +160,7 @@ def test_apple_sally_real_fixture_smoke(hpo_parser, now_ts):
     assert len(pps) == 1
     pp = pps[0]
     assert pp.id == "applesally-fetus-1"
-    assert pp.subject.id == "fetus-1"
+    assert pp.subject.id == "applesally-fetus-1"
     assert pp.phenotypic_features  # has at least one term
     for pf in pp.phenotypic_features:
         assert pf.type.id.startswith("HP:")

--- a/tests/builders/test_observer_phenopacket.py
+++ b/tests/builders/test_observer_phenopacket.py
@@ -132,6 +132,35 @@ def test_twin_returns_two_phenopackets(hpo_parser, now_ts):
     assert any("crown" in d.lower() or "crl" in d.lower() for d in twin2_descriptions)
 
 
+def test_subject_id_stable_across_exams_in_same_pregnancy(hpo_parser, now_ts):
+    data = _exam([_fetus_full_biometry(1)])
+
+    exam_2 = build_observer_phenopacket(
+        data, hpo_parser, now_ts, accession_id="B567817-U-1-2"
+    )[0]
+    exam_3 = build_observer_phenopacket(
+        data, hpo_parser, now_ts, accession_id="B567817-U-1-3"
+    )[0]
+
+    assert exam_2.subject.id == exam_3.subject.id == "b567817-preg1-fetus-1"
+    assert exam_2.id != exam_3.id
+
+
+def test_subject_id_differs_across_separate_pregnancies(hpo_parser, now_ts):
+    data = _exam([_fetus_full_biometry(1)])
+
+    pregnancy_1 = build_observer_phenopacket(
+        data, hpo_parser, now_ts, accession_id="B567817-U-1-1"
+    )[0]
+    pregnancy_2 = build_observer_phenopacket(
+        data, hpo_parser, now_ts, accession_id="B567817-U-2-1"
+    )[0]
+
+    assert pregnancy_1.subject.id == "b567817-preg1-fetus-1"
+    assert pregnancy_2.subject.id == "b567817-preg2-fetus-1"
+    assert pregnancy_1.subject.id != pregnancy_2.subject.id
+
+
 def test_unknown_fetus_returns_empty_features_phenopacket(hpo_parser, now_ts):
     data = _exam([_fetus_unknown(1)])
 

--- a/tests/builders/test_observer_phenopacket.py
+++ b/tests/builders/test_observer_phenopacket.py
@@ -155,13 +155,11 @@ def test_apple_sally_real_fixture_smoke(hpo_parser, now_ts):
     """End-to-end on a real Observer JSON fixture (single fetus, T2/T3)."""
     raw = json.loads((DATA_DIR / "Apple_Sally_pretty.json").read_text())
 
-    pps = build_observer_phenopacket(
-        raw, hpo_parser, now_ts, accession_id="apple-sally"
-    )
+    pps = build_observer_phenopacket(raw, hpo_parser, now_ts, accession_id="applesally")
 
     assert len(pps) == 1
     pp = pps[0]
-    assert pp.id == "apple-sally-fetus-1"
+    assert pp.id == "applesally-fetus-1"
     assert pp.subject.id == "fetus-1"
     assert pp.phenotypic_features  # has at least one term
     for pf in pp.phenotypic_features:


### PR DESCRIPTION
Make `subject.id` stable across a patient's exams

`subject.id` was just the fetus number (fetus-1, fetus-2, ...), so the same patient scanned on different days collided with unrelated patients on the same number, and two different pregnancies of the same patient would have collided