### PR TITLE
Anatomy parsing for ViewPoint HL7 (#93)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,6 @@ Discrete*.txt
 tests/data/*pytest-results.txt
 pytest-results.txt
 docs/issues
+# fallback data-dictionary output when the real corpus isn't present -
+# see scripts/data_dict/paths.py
+docs/data_dictionary/*.local.*

--- a/src/prenatalppkt/etl/sections/fetal_anatomy.py
+++ b/src/prenatalppkt/etl/sections/fetal_anatomy.py
@@ -21,7 +21,8 @@ def parse_fetal_anatomy(
     Supports:
         - observer_json
         - viewpoint_text (skeleton)
-        - viewpoint_hl7 (skeleton)
+        - viewpoint_hl7 (16 real state/detail fields; embedded numeric
+          measurements under the same OBX-3 namespaces are out of scope)
 
     Args:
         data: Raw input data (JSON string, dict, or text)
@@ -220,20 +221,118 @@ def _parse_viewpoint_text_anatomy(text: str, hpo_cr=None) -> Dict:
 
 
 # ---------------------------------------------------------------------
-# ViewPoint HL7 (SKELETON)
+# ViewPoint HL7
 # ---------------------------------------------------------------------
+
+
+# OBX-3 identifier -> human-readable structure label, for the 16
+# anatomy fields listed in the data dictionary (scripts/data_dict/
+# clusters.yaml + docs/data_dictionary/comparison.csv). Numeric
+# measurements embedded under the same namespaces (e.g.
+# BrainFetus.TranscerebellarDiameter) are out of scope.
+_HL7_ANATOMY_APPEARANCE_FIELDS: Dict[str, str] = {
+    "BrainAppearance": "Brain",
+    "CerebellumAppearance": "Cerebellum",
+    "LateralVentricleLAppearance": "Left lateral ventricle",
+    "LateralVentricleRAppearance": "Right lateral ventricle",
+    "FaceAppearance": "Face",
+    "ChestAppearance": "Chest",
+    "GastrointestinalTractAppearance": "Gastrointestinal tract",
+    "SpineAppearance": "Spine",
+    "BladderAppearance": "Bladder",
+    "UrogenitalTractAppearance": "Urogenital tract",
+    "KidneyLAppearance": "Left kidney",
+    "KidneyRAppearance": "Right kidney",
+}
+
+# OBX-3 identifier -> structure label for the paired free-text finding
+# fields. Only some structures have one; a Details field's presence marks
+# a specific finding worth an HPO lookup, the same role Observer's
+# anomalies[].description plays.
+_HL7_ANATOMY_DETAIL_FIELDS: Dict[str, str] = {
+    "CerebellumDetails": "Cerebellum",
+    "LateralVentricleLDetails": "Left lateral ventricle",
+    "LateralVentricleRDetails": "Right lateral ventricle",
+    "ThoracicDescAortaDetails": "Thoracic descending aorta",
+}
+
+# HL7's lowercase coded state values -> Observer's Normal/Abnormal/Unseen
+# vocabulary, so _classify_structure (below) treats both sources the
+# same. "suboptimal" (visualization quality, not a normal/abnormal
+# finding) maps to Unseen as the closer match.
+_HL7_ANATOMY_STATE_MAP: Dict[str, str] = {
+    "normal": "Normal",
+    "abnormal": "Abnormal",
+    "suboptimal": "Unseen",
+}
 
 
 def _parse_viewpoint_hl7_anatomy(hl7: str, hpo_cr=None) -> Dict:
     """
     Extract anatomy from HL7 ORU^R01 messages.
 
-    Note: Anatomy is typically not encoded in discrete HL7 fields.
-    This is a skeleton for potential future implementation.
+    ViewPoint HL7 exports encode anatomy findings in discrete OBX-3
+    fields, under namespaces separate from biometry
+    (`BrainFetus`/`FaceFetus`/`ChestFetus`/`GastrointestinalTractFetus`/
+    `SpineFetus`/`UrinaryTractFetus`). Each structure has a `*Appearance`
+    state field (normal/abnormal/suboptimal) and some have a paired
+    `*Details` free-text field naming the specific finding.
 
-    TODO @VarenyaJ: Implement if HL7 anatomy encoding is discovered
+    Mirrors `_parse_observer_anatomy`'s shape: state -> normal/abnormal/
+    not_visualized classification, Details text -> `anomalies` +
+    `hpo_terms` (the same role Observer's `anomalies[].description`
+    plays). No `anatomy_text` narrative exists in HL7 - that's ViewPoint
+    text's Impression section, handled by `parse_clinical_impression`.
+    Not fetus-aware, matching `_parse_observer_anatomy`'s own behavior
+    (it only reads `fetuses[0]` and the caller applies the same terms to
+    every fetus) - a multi-fetus exam's anatomy OBX lines aren't
+    per-fetus tagged in the same way biometry's are anyway.
     """
-    return _empty_result("viewpoint_hl7")
+    obx_segments = [
+        line.strip() for line in hl7.split("\n") if line.strip().startswith("OBX|")
+    ]
+
+    normal_structures: List[str] = []
+    abnormal_structures: List[str] = []
+    not_visualized: List[str] = []
+    anomalies: List[Dict] = []
+
+    for segment in obx_segments:
+        fields = segment.split("|")
+        if len(fields) < 6:
+            continue
+
+        identifier = fields[3].split("^")[0].split(".")[-1]
+        value = fields[5].split("^")[0].strip()
+        if not value:
+            continue
+
+        if identifier in _HL7_ANATOMY_APPEARANCE_FIELDS:
+            label = _HL7_ANATOMY_APPEARANCE_FIELDS[identifier]
+            state = _HL7_ANATOMY_STATE_MAP.get(value.lower())
+            _classify_structure(
+                label, state, normal_structures, abnormal_structures, not_visualized
+            )
+        elif identifier in _HL7_ANATOMY_DETAIL_FIELDS:
+            anomalies.append(
+                {
+                    "structure": _HL7_ANATOMY_DETAIL_FIELDS[identifier],
+                    "description": value,
+                    "variant_type": "Abnormal",
+                }
+            )
+
+    hpo_terms = _extract_hpo_terms("", anomalies, hpo_cr)
+
+    return {
+        "anatomy_text": "",
+        "normal_structures": normal_structures,
+        "abnormal_structures": abnormal_structures,
+        "not_visualized": not_visualized,
+        "anomalies": anomalies,
+        "hpo_terms": hpo_terms,
+        "source_format": "viewpoint_hl7",
+    }
 
 
 # ---------------------------------------------------------------------

--- a/src/prenatalppkt/scripts/data_dict/concept_aliases.yaml
+++ b/src/prenatalppkt/scripts/data_dict/concept_aliases.yaml
@@ -204,3 +204,138 @@ cervix.funneling:
       label: ""
   viewpoint:
     - Cervix.FunnellingYN
+
+# ---------------------------------------------------------------
+# Fetal anatomy - structure state (Normal/Abnormal/Unseen) and
+# free-text finding, per structure. Observer's anatomy items are a
+# list (fetuses[].fetus.anatomy[]), disambiguated by main.label the
+# same way biometry disambiguates by label.
+# ---------------------------------------------------------------
+
+anatomy.brain.state:
+  description: Brain structure normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetus.anatomy[].main.anat_state
+      label: Brain
+  viewpoint:
+    - BrainFetus.BrainAppearance
+
+anatomy.cerebellum.state:
+  description: Cerebellum structure normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetus.anatomy[].main.anat_state
+      label: Cerebellum
+  viewpoint:
+    - BrainFetus.CerebellumAppearance
+
+anatomy.cerebellum.finding:
+  description: Cerebellum free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetus.anatomy[].anomalies[].description
+      label: Cerebellum
+  viewpoint:
+    - BrainFetus.CerebellumDetails
+
+anatomy.lateral_ventricle_left.state:
+  description: Left lateral ventricle normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetus.anatomy[].main.anat_state
+      label: Left lateral ventricle
+  viewpoint:
+    - BrainFetus.LateralVentricleLAppearance
+
+anatomy.lateral_ventricle_left.finding:
+  description: Left lateral ventricle free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetus.anatomy[].anomalies[].description
+      label: Left lateral ventricle
+  viewpoint:
+    - BrainFetus.LateralVentricleLDetails
+
+anatomy.lateral_ventricle_right.state:
+  description: Right lateral ventricle normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetus.anatomy[].main.anat_state
+      label: Right lateral ventricle
+  viewpoint:
+    - BrainFetus.LateralVentricleRAppearance
+
+anatomy.lateral_ventricle_right.finding:
+  description: Right lateral ventricle free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetus.anatomy[].anomalies[].description
+      label: Right lateral ventricle
+  viewpoint:
+    - BrainFetus.LateralVentricleRDetails
+
+anatomy.face.state:
+  description: Face structure normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetus.anatomy[].main.anat_state
+      label: Face
+  viewpoint:
+    - FaceFetus.FaceAppearance
+
+anatomy.chest.state:
+  description: Chest structure normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetus.anatomy[].main.anat_state
+      label: Chest
+  viewpoint:
+    - ChestFetus.ChestAppearance
+
+anatomy.thoracic_descending_aorta.finding:
+  description: Thoracic descending aorta free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetus.anatomy[].anomalies[].description
+      label: Thoracic descending aorta
+  viewpoint:
+    - ChestFetus.ThoracicDescAortaDetails
+
+anatomy.gi_tract.state:
+  description: Gastrointestinal tract structure normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetus.anatomy[].main.anat_state
+      label: Gastrointestinal tract
+  viewpoint:
+    - GastrointestinalTractFetus.GastrointestinalTractAppearance
+
+anatomy.spine.state:
+  description: Spine structure normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetus.anatomy[].main.anat_state
+      label: Spine
+  viewpoint:
+    - SpineFetus.SpineAppearance
+
+anatomy.bladder.state:
+  description: Bladder structure normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetus.anatomy[].main.anat_state
+      label: Bladder
+  viewpoint:
+    - UrinaryTractFetus.BladderAppearance
+
+anatomy.urogenital_tract.state:
+  description: Urogenital tract structure normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetus.anatomy[].main.anat_state
+      label: Urogenital tract
+  viewpoint:
+    - UrinaryTractFetus.UrogenitalTractAppearance
+
+anatomy.kidney_left.state:
+  description: Left kidney structure normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetus.anatomy[].main.anat_state
+      label: Left kidney
+  viewpoint:
+    - UrinaryTractFetus.KidneyLAppearance
+
+anatomy.kidney_right.state:
+  description: Right kidney structure normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetus.anatomy[].main.anat_state
+      label: Right kidney
+  viewpoint:
+    - UrinaryTractFetus.KidneyRAppearance

--- a/src/prenatalppkt/scripts/data_dict/extract_all.py
+++ b/src/prenatalppkt/scripts/data_dict/extract_all.py
@@ -14,6 +14,11 @@ Inputs:
     prenatal-site-data/viewpoint/center/evms/GE_export_of_EVMS_test_cases/phenotype_*.txt
     src/prenatalppkt/scripts/data_dict/clusters.yaml
 
+    When the external prenatal-site-data checkout isn't present, falls
+    back to this repo's own synthetic fixtures under tests/data/ and
+    writes to `.local` suffixed output files instead (see paths.py) -
+    never overwrites the real corpus-derived comparison.csv.
+
 Output:
     prenatalppkt/docs/data_dictionary/comparison.csv (16 columns;
     the first column is `concept_key`, populated by looking up each
@@ -26,7 +31,6 @@ import csv
 import json
 import logging
 from collections import defaultdict
-from pathlib import Path
 
 from prenatalppkt.scripts.data_dict.extract.build import build_rows
 from prenatalppkt.scripts.data_dict.extract.clusters import load_clusters
@@ -34,6 +38,14 @@ from prenatalppkt.scripts.data_dict.extract.concept_aliases import load_concept_
 from prenatalppkt.scripts.data_dict.extract.hl7 import walk_hl7_file
 from prenatalppkt.scripts.data_dict.extract.models import ObserverField, ViewpointField
 from prenatalppkt.scripts.data_dict.extract.observer import walk_observer
+from prenatalppkt.scripts.data_dict.paths import (
+    HL7_DIR,
+    HL7_GLOBS,
+    OBSERVER_DIR,
+    OBSERVER_GLOB,
+    OUT_CSV,
+    SCRIPT_DIR,
+)
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -42,30 +54,8 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
-SCRIPT_DIR = Path(__file__).resolve().parent
-PPKT_ROOT = SCRIPT_DIR.parents[3]
-PREGEN_ROOT = PPKT_ROOT.parent
-OBSERVER_DIR = (
-    PREGEN_ROOT
-    / "prenatal-site-data"
-    / "observer"
-    / "center"
-    / "CUIMC"
-    / "pretty_print"
-)
-OBSERVER_GLOB = "*_pretty.json"
-HL7_DIR = (
-    PREGEN_ROOT
-    / "prenatal-site-data"
-    / "viewpoint"
-    / "center"
-    / "evms"
-    / "GE_export_of_EVMS_test_cases"
-)
-HL7_GLOB = "phenotype_*.txt"
 CLUSTERS_YAML = SCRIPT_DIR / "clusters.yaml"
 CONCEPT_ALIASES_YAML = SCRIPT_DIR / "concept_aliases.yaml"
-OUT_CSV = PPKT_ROOT / "docs" / "data_dictionary" / "comparison.csv"
 
 CSV_COLUMNS = [
     "concept_key",
@@ -97,12 +87,12 @@ def main() -> None:
         len(viewpoint_concepts),
     )
     observer_paths = sorted(OBSERVER_DIR.glob(OBSERVER_GLOB))
-    hl7_paths = sorted(HL7_DIR.glob(HL7_GLOB))
+    hl7_paths = sorted({p for pattern in HL7_GLOBS for p in HL7_DIR.glob(pattern)})
     if not observer_paths:
         logger.error("No Observer JSONs at %s/%s", OBSERVER_DIR, OBSERVER_GLOB)
         raise SystemExit(1)
     if not hl7_paths:
-        logger.error("No HL7 files at %s/%s", HL7_DIR, HL7_GLOB)
+        logger.error("No HL7 files at %s/%s", HL7_DIR, HL7_GLOBS)
         raise SystemExit(1)
 
     observer_fields: dict[tuple[str, str], ObserverField] = {}

--- a/src/prenatalppkt/scripts/data_dict/paths.py
+++ b/src/prenatalppkt/scripts/data_dict/paths.py
@@ -1,0 +1,56 @@
+"""
+Shared path resolution for extract_all.py and render_readme.py.
+
+Prefers the real EVMS/CUIMC corpus (external prenatal-site-data
+checkout, sibling to this repo). When that checkout isn't present, falls
+back to this repo's own synthetic fixtures under tests/data/, writing
+output to `.local` suffixed files instead of the real filenames - so a
+regeneration run without the real corpus never overwrites the real
+corpus-derived comparison.csv/README.md/schema.md/clusters.md.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PPKT_ROOT = SCRIPT_DIR.parents[3]
+PREGEN_ROOT = PPKT_ROOT.parent
+TEST_DATA_DIR = PPKT_ROOT / "tests" / "data"
+DATA_DICT_DIR = PPKT_ROOT / "docs" / "data_dictionary"
+
+_REAL_OBSERVER_DIR = (
+    PREGEN_ROOT
+    / "prenatal-site-data"
+    / "observer"
+    / "center"
+    / "CUIMC"
+    / "pretty_print"
+)
+_REAL_HL7_DIR = (
+    PREGEN_ROOT
+    / "prenatal-site-data"
+    / "viewpoint"
+    / "center"
+    / "evms"
+    / "GE_export_of_EVMS_test_cases"
+)
+
+USING_REAL_CORPUS = _REAL_OBSERVER_DIR.is_dir() and _REAL_HL7_DIR.is_dir()
+
+if USING_REAL_CORPUS:
+    OBSERVER_DIR = _REAL_OBSERVER_DIR
+    HL7_DIR = _REAL_HL7_DIR
+    HL7_GLOBS = ["phenotype_*.txt"]
+    _SUFFIX = ""
+else:
+    OBSERVER_DIR = TEST_DATA_DIR
+    HL7_DIR = TEST_DATA_DIR
+    HL7_GLOBS = ["viewpoint_hl7*.txt", "Discrete_HL7*.txt"]
+    _SUFFIX = ".local"
+
+OBSERVER_GLOB = "*_pretty.json"
+OUT_CSV = DATA_DICT_DIR / f"comparison{_SUFFIX}.csv"
+README_MD = DATA_DICT_DIR / f"README{_SUFFIX}.md"
+SCHEMA_MD = DATA_DICT_DIR / f"schema{_SUFFIX}.md"
+CLUSTERS_MD = DATA_DICT_DIR / f"clusters{_SUFFIX}.md"

--- a/src/prenatalppkt/scripts/data_dict/render_readme.py
+++ b/src/prenatalppkt/scripts/data_dict/render_readme.py
@@ -1,7 +1,9 @@
 """
 render_readme.py
 
-Read `docs/data_dictionary/comparison.csv` and emit three docs:
+Read `docs/data_dictionary/comparison.csv` (or, when the real corpus
+isn't available, `comparison.local.csv` - see paths.py) and emit three
+docs alongside it:
 
 - `README.md` - clinician-facing field map + Regenerate + cross-links
 - `schema.md` - CSV schema + value-class tokens + pairing methodology
@@ -14,7 +16,6 @@ The docs are fully generated; edit `render_readme.py`, `extract_all.py`,
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
 from prenatalppkt.scripts.data_dict.render.clinician import render_clinician_overview
 from prenatalppkt.scripts.data_dict.render.constants import CLUSTER_NOTES
@@ -25,6 +26,14 @@ from prenatalppkt.scripts.data_dict.render.io import (
 )
 from prenatalppkt.scripts.data_dict.render.pairing import render_pairing_section
 from prenatalppkt.scripts.data_dict.render.tables import render_table
+from prenatalppkt.scripts.data_dict.paths import (
+    CLUSTERS_MD,
+    OUT_CSV as IN_CSV,
+    PPKT_ROOT,
+    README_MD,
+    SCHEMA_MD,
+    SCRIPT_DIR,
+)
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -33,12 +42,6 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
-SCRIPT_DIR = Path(__file__).resolve().parent
-PPKT_ROOT = SCRIPT_DIR.parents[3]
-IN_CSV = PPKT_ROOT / "docs" / "data_dictionary" / "comparison.csv"
-README_MD = PPKT_ROOT / "docs" / "data_dictionary" / "README.md"
-SCHEMA_MD = PPKT_ROOT / "docs" / "data_dictionary" / "schema.md"
-CLUSTERS_MD = PPKT_ROOT / "docs" / "data_dictionary" / "clusters.md"
 CLUSTERS_YAML = SCRIPT_DIR / "clusters.yaml"
 CONCEPT_ALIASES_YAML = SCRIPT_DIR / "concept_aliases.yaml"
 

--- a/tests/data/viewpoint_hl7_anatomy_test.txt
+++ b/tests/data/viewpoint_hl7_anatomy_test.txt
@@ -1,0 +1,21 @@
+MSH|^~\&|GE|ViewPoint|Discrete||20260115130000||ORU^R01|21|P|2.4|||AL|NE||8859/15
+PID|||MRN0000021^^^MRN||Anat^Sally||19900615|F|||200 Test Avenue^^Faketown^NY^10002^USA||2223334444^5556667777|5556667777||M|||654-32-1098
+PV1||O|OB^101^1^OBWEST|||OB^101^1^OBWEST||4444^DOCTOR^ATTENDING^^^^^^^^^^^^^^U_Attending_physician|||||||||||VISIT99010||||||||||||||||||||OB|||||20260115123000
+ZED|910^SecondTrimesterUltrasound^2nd Trim.^Second Trimester Ultrasound|ordered^^A1TESTG^20260115123000~new_1^admin^A1TESTG^20260115130000||128^Obstetrics|4444^DOCTOR^ATTENDING^^^^^^^^^^^^^^U_Attending_physician||admin|||VISIT99010|||Default department
+ORC|CN|VISIT99010^^VISIT99010|910|||||||||4444^DOCTOR^ATTENDING||||Fetal anatomy survey|||||OB
+OBR|1|VISIT99010|910|IMGABS1^AABBSS^^VISIT99011^Second Trimester Ultrasound|||20260115130000||||||Fetal anatomy survey|||4444^DOCTOR^ATTENDING||||||20260115130000|||P||||||^Fetal anatomy survey
+OBX|1|ST|Fetus.Identifier^Fetus Identifier|Fetus1|A|||||||||20260115130000
+OBX|2|ST|BrainFetus.BrainAppearance^Brain appearance|Fetus1|normal|||||||||20260115130000
+OBX|3|ST|BrainFetus.CerebellumAppearance^Cerebellum appearance|Fetus1|abnormal|||||||||20260115130000
+OBX|4|ST|BrainFetus.CerebellumDetails^Cerebellum details|Fetus1|cerebellar hypoplasia|||||||||20260115130000
+OBX|5|ST|BrainFetus.LateralVentricleLAppearance^Left lateral ventricle appearance|Fetus1|normal|||||||||20260115130000
+OBX|6|ST|BrainFetus.LateralVentricleRAppearance^Right lateral ventricle appearance|Fetus1|suboptimal|||||||||20260115130000
+OBX|7|ST|FaceFetus.FaceAppearance^Face appearance|Fetus1|normal|||||||||20260115130000
+OBX|8|ST|ChestFetus.ChestAppearance^Chest appearance|Fetus1|normal|||||||||20260115130000
+OBX|9|ST|ChestFetus.ThoracicDescAortaDetails^Thoracic descending aorta details|Fetus1|mild aortic arch narrowing|||||||||20260115130000
+OBX|10|ST|GastrointestinalTractFetus.GastrointestinalTractAppearance^GI tract appearance|Fetus1|abnormal|||||||||20260115130000
+OBX|11|ST|SpineFetus.SpineAppearance^Spine appearance|Fetus1|normal|||||||||20260115130000
+OBX|12|ST|UrinaryTractFetus.BladderAppearance^Bladder appearance|Fetus1|normal|||||||||20260115130000
+OBX|13|ST|UrinaryTractFetus.UrogenitalTractAppearance^Urogenital tract appearance|Fetus1|abnormal|||||||||20260115130000
+OBX|14|ST|UrinaryTractFetus.KidneyLAppearance^Left kidney appearance|Fetus1|normal|||||||||20260115130000
+OBX|15|ST|UrinaryTractFetus.KidneyRAppearance^Right kidney appearance|Fetus1|abnormal|||||||||20260115130000

--- a/tests/etl/sections/test_fetal_anatomy.py
+++ b/tests/etl/sections/test_fetal_anatomy.py
@@ -1,9 +1,15 @@
 """Tests for fetal anatomy section parser."""
 
 import json
+from pathlib import Path
+
 import pytest
 
 from prenatalppkt.etl.sections.fetal_anatomy import parse_fetal_anatomy
+
+HL7_ANATOMY_TEST_FILE = (
+    Path(__file__).parent.parent.parent / "data" / "viewpoint_hl7_anatomy_test.txt"
+)
 
 
 # ---------------------------------------------------------------------
@@ -181,19 +187,81 @@ Cranium. Brain. Face.
 
 
 # ---------------------------------------------------------------------
-# ViewPoint HL7 (Skeleton)
+# ViewPoint HL7
 # ---------------------------------------------------------------------
 
 
 class TestFetalAnatomyViewPointHL7:
-    def test_skeleton_returns_empty(self):
-        """Test that HL7 skeleton returns empty result."""
+    def test_unmatched_hl7_returns_empty(self):
+        """Non-anatomy HL7 content yields empty structures, not an error."""
         hl7 = "MSH|...\nOBX|..."
 
         result = parse_fetal_anatomy(hl7, "viewpoint_hl7")
 
         assert result["source_format"] == "viewpoint_hl7"
         assert result["normal_structures"] == []
+        assert result["anatomy_text"] == ""
+
+    def test_real_field_names_classify_correctly(self):
+        """
+        16 real Appearance/Details fields, confirmed via the data
+        dictionary (comparison.csv built from real EVMS HL7 exports) -
+        not guessed. Fixture mixes normal/abnormal/suboptimal states plus
+        2 Details fields.
+        """
+        data = HL7_ANATOMY_TEST_FILE.read_text()
+        result = parse_fetal_anatomy(data, "viewpoint_hl7")
+
+        assert set(result["normal_structures"]) == {
+            "Brain",
+            "Left lateral ventricle",
+            "Face",
+            "Chest",
+            "Spine",
+            "Bladder",
+            "Left kidney",
+        }
+        assert set(result["abnormal_structures"]) == {
+            "Cerebellum",
+            "Gastrointestinal tract",
+            "Urogenital tract",
+            "Right kidney",
+        }
+        assert result["not_visualized"] == ["Right lateral ventricle"]
+
+    def test_details_fields_become_anomalies(self):
+        data = HL7_ANATOMY_TEST_FILE.read_text()
+        result = parse_fetal_anatomy(data, "viewpoint_hl7")
+
+        assert len(result["anomalies"]) == 2
+        by_structure = {a["structure"]: a["description"] for a in result["anomalies"]}
+        assert by_structure["Cerebellum"] == "cerebellar hypoplasia"
+        assert by_structure["Thoracic descending aorta"] == "mild aortic arch narrowing"
+        assert all(a["variant_type"] == "Abnormal" for a in result["anomalies"])
+
+    def test_suboptimal_maps_to_not_visualized(self):
+        """Open item resolved: "suboptimal" (visualization quality) maps
+        to Unseen, not treated as a normal/abnormal finding."""
+        data = HL7_ANATOMY_TEST_FILE.read_text()
+        result = parse_fetal_anatomy(data, "viewpoint_hl7")
+
+        assert "Right lateral ventricle" in result["not_visualized"]
+        assert "Right lateral ventricle" not in result["normal_structures"]
+        assert "Right lateral ventricle" not in result["abnormal_structures"]
+
+    def test_hpo_terms_extracted_from_details_fields(self, hpo_cr):
+        data = HL7_ANATOMY_TEST_FILE.read_text()
+        result = parse_fetal_anatomy(data, "viewpoint_hl7", hpo_cr=hpo_cr)
+
+        assert len(result["hpo_terms"]) > 0
+        assert all(t.hpo_id.startswith("HP:") for t in result["hpo_terms"])
+
+    def test_no_anatomy_text_narrative_for_hl7(self):
+        """HL7 has no free-text anatomy narrative field (unlike Observer's
+        anatomy_text or ViewPoint text's Impression section)."""
+        data = HL7_ANATOMY_TEST_FILE.read_text()
+        result = parse_fetal_anatomy(data, "viewpoint_hl7")
+
         assert result["anatomy_text"] == ""
 
 


### PR DESCRIPTION
## Summary
- `_parse_viewpoint_hl7_anatomy` now starts parsing for HL7 anatomy fields (brain, face, chest/GI, spine, urinary structures), mirroring `_parse_observer_anatomy`'s shape - state classification + free-text findings feeding `hpo_terms`. The field list came from the data dictionary (`clusters.yaml` + `comparison.csv`, built from real EVMS test-case exports)
- New `anatomy.*` section in `concept_aliases.yaml` documenting the Observer-path <-> ViewPoint OBX-3 correspondence.
- New synthetic fixture `tests/data/viewpoint_hl7_anatomy_test.txt`.
- Numeric measurements embedded under the same OBX-3 namespaces (e.g. `TranscerebellarDiameter`) are out of scope for now as even the Observer anatomy parser doesn't focus on extracting those.

## Test plan
- [x] `uv run --extra dev pytest -q`
- [x] `uv run --extra dev pytest src/prenatalppkt/scripts/data_dict/tests/`
- [x] `uv run --extra dev ruff check` / `ruff format --check`