### PR TITLE
build_viewpoint_phenopacket - the ViewPoint HL7 builder (#93)

### DIFF
--- a/src/prenatalppkt/builders/__init__.py
+++ b/src/prenatalppkt/builders/__init__.py
@@ -1,5 +1,6 @@
 """Phenopacket v2 builders for prenatalppkt-extracted clinical data."""
 
 from prenatalppkt.builders.observer_phenopacket import build_observer_phenopacket
+from prenatalppkt.builders.viewpoint_phenopacket import build_viewpoint_phenopacket
 
-__all__ = ["build_observer_phenopacket"]
+__all__ = ["build_observer_phenopacket", "build_viewpoint_phenopacket"]

--- a/src/prenatalppkt/builders/viewpoint_phenopacket.py
+++ b/src/prenatalppkt/builders/viewpoint_phenopacket.py
@@ -1,0 +1,187 @@
+"""ViewPoint HL7 -> Phenopacket v2 builder.
+
+One ViewPoint HL7 message describes one exam with one or more fetuses.
+This module stitches `extract_all_fetuses` output together with the
+exam-level section parses (impression, anatomy, pregnancy dating) and
+returns one `Phenopacket` per fetus. The caller decides what to do with
+fetuses that yielded no phenotypic features.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+import phenopackets.schema.v2 as pps2
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from prenatalppkt.etl.extractors import viewpoint_hl7
+from prenatalppkt.etl.sections import (
+    parse_clinical_impression,
+    parse_fetal_anatomy,
+    parse_pregnancy_dating,
+)
+from prenatalppkt.gestational_age import GestationalAge
+from prenatalppkt.hpo import HpoParser
+from prenatalppkt.measurements.term_bin import TermBin
+
+
+_GA_PATTERN = re.compile(r"at (\d+)w(\d+)d")
+_DEFAULT_GA = GestationalAge(weeks=27, days=0)
+
+
+def _parse_ga_from_description(description: str) -> Optional[tuple[int, int]]:
+    m = _GA_PATTERN.search(description or "")
+    if m:
+        return (int(m.group(1)), int(m.group(2)))
+    return None
+
+
+def _resolve_subject_ga(dating: dict, term_bins: list[TermBin]) -> GestationalAge:
+    ga_weeks = dating.get("ga_weeks")
+    if ga_weeks:
+        return GestationalAge.from_weeks(float(ga_weeks))
+    for tb in term_bins:
+        parsed = _parse_ga_from_description(tb.description)
+        if parsed is not None:
+            w, d = parsed
+            return GestationalAge(weeks=w, days=d)
+    return _DEFAULT_GA
+
+
+def _biometry_feature(tb: TermBin) -> pps2.PhenotypicFeature:
+    parsed = _parse_ga_from_description(tb.description)
+    if parsed is not None:
+        w, d = parsed
+    else:
+        w, d = _DEFAULT_GA.weeks, _DEFAULT_GA.days
+    return pps2.PhenotypicFeature(
+        type=pps2.OntologyClass(id=tb.hpo_id, label=tb.hpo_label),
+        excluded=tb.normal,
+        description=f"Biometry: {tb.description}",
+        onset=pps2.TimeElement(gestational_age=pps2.GestationalAge(weeks=w, days=d)),
+    )
+
+
+def _narrative_feature(
+    term, description_prefix: str, subject_ga: GestationalAge
+) -> pps2.PhenotypicFeature:
+    return pps2.PhenotypicFeature(
+        type=pps2.OntologyClass(id=term.hpo_id, label=term.hpo_label),
+        description=description_prefix,
+        onset=pps2.TimeElement(
+            gestational_age=pps2.GestationalAge(
+                weeks=subject_ga.weeks, days=subject_ga.days
+            )
+        ),
+    )
+
+
+def _dedup_by_hpo_id(
+    features: list[pps2.PhenotypicFeature],
+) -> list[pps2.PhenotypicFeature]:
+    seen: set[str] = set()
+    out: list[pps2.PhenotypicFeature] = []
+    for pf in features:
+        if pf.type.id in seen:
+            continue
+        seen.add(pf.type.id)
+        out.append(pf)
+    return out
+
+
+def _hpo_resource(hpo_parser: HpoParser) -> pps2.Resource:
+    return pps2.Resource(
+        id="hp",
+        name="human phenotype ontology",
+        url="http://purl.obolibrary.org/obo/hp.owl",
+        version=hpo_parser.get_version() or "unknown",
+        namespace_prefix="HP",
+        iri_prefix="http://purl.obolibrary.org/obo/HP_",
+    )
+
+
+def _phenopacket_id(accession_id: Optional[str], fetus_number: int) -> str:
+    if accession_id:
+        return f"{accession_id.lower().replace('_', '-')}-fetus-{fetus_number}"
+    return f"fetus-{fetus_number}"
+
+
+def _subject_id(accession_id: Optional[str], fetus_number: int) -> str:
+    if accession_id:
+        parts = accession_id.lower().replace("_", "-").split("-")
+        patient = parts[0]
+        if len(parts) > 2:
+            return f"{patient}-preg{parts[2]}-fetus-{fetus_number}"
+        return f"{patient}-fetus-{fetus_number}"
+    return f"fetus-{fetus_number}"
+
+
+def build_viewpoint_phenopacket(
+    data: str,
+    hpo_parser: HpoParser,
+    created_at: Timestamp,
+    *,
+    accession_id: Optional[str] = None,
+) -> list[pps2.Phenopacket]:
+    """Build one Phenopacket per fetus from a ViewPoint HL7 message string.
+
+    Args:
+        data: ViewPoint HL7 message content as string.
+        hpo_parser: Loaded HpoParser for the concept recognizer + resource version.
+        created_at: Timestamp to stamp into each Phenopacket's MetaData.
+        accession_id: Optional exam accession to use as the subject-id prefix.
+
+    Returns:
+        One Phenopacket per fetus found in `data`. A fetus whose
+        extraction yielded no term bins produces a Phenopacket with no
+        phenotypic features so the caller can decide whether to drop it.
+    """
+    hpo_cr = hpo_parser.get_hpo_concept_recognizer()
+
+    bins_by_fetus = viewpoint_hl7.extract_all_fetuses(data)
+    dating = parse_pregnancy_dating(data, "viewpoint_hl7")
+    impression = parse_clinical_impression(data, "viewpoint_hl7", hpo_cr=hpo_cr)
+    anatomy = parse_fetal_anatomy(data, "viewpoint_hl7", hpo_cr=hpo_cr)
+
+    hp_resource = _hpo_resource(hpo_parser)
+    impression_terms = impression.get("hpo_terms", [])
+    anatomy_terms = anatomy.get("hpo_terms", [])
+
+    phenopackets: list[pps2.Phenopacket] = []
+    for fetus_number, term_bins in bins_by_fetus.items():
+        subject_ga = _resolve_subject_ga(dating, term_bins)
+        features: list[pps2.PhenotypicFeature] = [
+            _biometry_feature(tb) for tb in term_bins
+        ]
+        for term in impression_terms:
+            features.append(
+                _narrative_feature(
+                    term, f"Clinical impression: {term.hpo_label}", subject_ga
+                )
+            )
+        for term in anatomy_terms:
+            features.append(_narrative_feature(term, "Fetal anatomy", subject_ga))
+        features = _dedup_by_hpo_id(features)
+
+        pp = pps2.Phenopacket(
+            id=_phenopacket_id(accession_id, fetus_number),
+            subject=pps2.Individual(
+                id=_subject_id(accession_id, fetus_number),
+                time_at_last_encounter=pps2.TimeElement(
+                    gestational_age=pps2.GestationalAge(
+                        weeks=subject_ga.weeks, days=subject_ga.days
+                    )
+                ),
+            ),
+            phenotypic_features=features,
+            meta_data=pps2.MetaData(
+                created=created_at,
+                created_by="prenatalppkt",
+                resources=[hp_resource],
+                phenopacket_schema_version="2.0",
+            ),
+        )
+        phenopackets.append(pp)
+
+    return phenopackets

--- a/tests/builders/test_viewpoint_phenopacket.py
+++ b/tests/builders/test_viewpoint_phenopacket.py
@@ -1,0 +1,139 @@
+"""Tests for prenatalppkt.builders.viewpoint_phenopacket."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from google.protobuf.json_format import MessageToJson, Parse
+from google.protobuf.timestamp_pb2 import Timestamp
+import phenopackets.schema.v2 as pps2
+
+from prenatalppkt.builders import build_viewpoint_phenopacket
+
+
+DATA_DIR = Path(__file__).parent.parent / "data"
+
+_SINGLE_FETUS_HL7 = """
+MSH|^~\\&|ViewPoint|Hospital|||20211223144928||ORU^R01|123456|P|2.4
+OBX|1|ST|Fetus.Identifier^Fetus Identifier|Fetus1|A
+OBX|2|NM|SkullFetus.HeadCircumference^HC|Fetus1|175^175.0|mm&millimeters^mm&millimeters
+OBX|3|NM|SkullFetus.VP_HeadCircumference_Percentile|Fetus1|50^50%|%&percent^fmt&formatted
+OBX|4|NM|AbdomenFetus.AbdominalCircumference^AC|Fetus1|212^212.0|mm&millimeters^mm&millimeters
+OBX|5|NM|AbdomenFetus.VP_AbdominalCircumference_Percentile|Fetus1|48^48%|%&percent^fmt&formatted
+"""
+
+
+@pytest.fixture
+def now_ts() -> Timestamp:
+    ts = Timestamp()
+    ts.FromDatetime(datetime.now(tz=timezone.utc))
+    return ts
+
+
+def test_single_fetus_returns_one_phenopacket(hpo_parser, now_ts):
+    pps = build_viewpoint_phenopacket(_SINGLE_FETUS_HL7, hpo_parser, now_ts)
+
+    assert len(pps) == 1
+    pp = pps[0]
+    assert pp.subject.id == "fetus-1"
+    assert pp.id == "fetus-1"
+    hpo_ids = {pf.type.id for pf in pp.phenotypic_features}
+    assert hpo_ids
+    for pf in pp.phenotypic_features:
+        assert pf.description.startswith("Biometry: ")
+    assert pp.meta_data.resources[0].namespace_prefix == "HP"
+    assert pp.meta_data.created_by == "prenatalppkt"
+
+
+def test_accession_id_prefixes_phenopacket_id(hpo_parser, now_ts):
+    pps = build_viewpoint_phenopacket(
+        _SINGLE_FETUS_HL7, hpo_parser, now_ts, accession_id="A000001_U_1_1"
+    )
+
+    assert pps[0].id == "a000001-u-1-1-fetus-1"
+    assert pps[0].subject.id == "a000001-preg1-fetus-1"
+
+
+def test_no_accession_falls_back(hpo_parser, now_ts):
+    pps = build_viewpoint_phenopacket(_SINGLE_FETUS_HL7, hpo_parser, now_ts)
+
+    assert pps[0].id == "fetus-1"
+    assert pps[0].subject.id == "fetus-1"
+
+
+def test_subject_id_stable_across_exams_in_same_pregnancy(hpo_parser, now_ts):
+    exam_2 = build_viewpoint_phenopacket(
+        _SINGLE_FETUS_HL7, hpo_parser, now_ts, accession_id="B567817-U-1-2"
+    )[0]
+    exam_3 = build_viewpoint_phenopacket(
+        _SINGLE_FETUS_HL7, hpo_parser, now_ts, accession_id="B567817-U-1-3"
+    )[0]
+
+    assert exam_2.subject.id == exam_3.subject.id == "b567817-preg1-fetus-1"
+    assert exam_2.id != exam_3.id
+
+
+def test_subject_id_differs_across_separate_pregnancies(hpo_parser, now_ts):
+    pregnancy_1 = build_viewpoint_phenopacket(
+        _SINGLE_FETUS_HL7, hpo_parser, now_ts, accession_id="B567817-U-1-1"
+    )[0]
+    pregnancy_2 = build_viewpoint_phenopacket(
+        _SINGLE_FETUS_HL7, hpo_parser, now_ts, accession_id="B567817-U-2-1"
+    )[0]
+
+    assert pregnancy_1.subject.id == "b567817-preg1-fetus-1"
+    assert pregnancy_2.subject.id == "b567817-preg2-fetus-1"
+    assert pregnancy_1.subject.id != pregnancy_2.subject.id
+
+
+def test_hpo_id_dedup_keeps_first_occurrence(hpo_parser, now_ts):
+    pps = build_viewpoint_phenopacket(_SINGLE_FETUS_HL7, hpo_parser, now_ts)
+
+    ids = [pf.type.id for pf in pps[0].phenotypic_features]
+    assert len(ids) == len(set(ids)), "PhenotypicFeature HPO ids must be unique"
+
+
+def test_twins_returns_two_phenopackets(hpo_parser, now_ts):
+    data = (DATA_DIR / "viewpoint_hl7_twins_test.txt").read_text()
+
+    pps = build_viewpoint_phenopacket(data, hpo_parser, now_ts, accession_id="TWIN")
+
+    assert len(pps) == 2
+    assert [pp.subject.id for pp in pps] == ["twin-fetus-1", "twin-fetus-2"]
+    assert [pp.id for pp in pps] == ["twin-fetus-1", "twin-fetus-2"]
+
+
+def test_full_exam_fixture_has_biometry_and_anatomy_features(hpo_parser, now_ts):
+    """End-to-end on a fixture with both biometry and the 16 anatomy fields.
+
+    HC and BPD share HP:0000240 ("Abnormality of skull size"), so the
+    existing HPO-id dedup collapses them to one - the same dedup
+    behavior Observer's builder already has, not something new here.
+    """
+    data = (DATA_DIR / "viewpoint_hl7_full_exam_test.txt").read_text()
+
+    pps = build_viewpoint_phenopacket(
+        data, hpo_parser, now_ts, accession_id="FULL00099"
+    )
+
+    assert len(pps) == 1
+    pp = pps[0]
+    descriptions = [pf.description for pf in pp.phenotypic_features]
+    assert any(d.startswith("Biometry: ") for d in descriptions)
+    assert any(d == "Fetal anatomy" for d in descriptions)
+    hpo_ids = {pf.type.id for pf in pp.phenotypic_features}
+    assert "HP:0001321" in hpo_ids  # Cerebellar hypoplasia, from the Details field
+
+
+def test_round_trips_through_message_to_json(hpo_parser, now_ts):
+    data = (DATA_DIR / "viewpoint_hl7_full_exam_test.txt").read_text()
+    pp = build_viewpoint_phenopacket(
+        data, hpo_parser, now_ts, accession_id="FULL00099"
+    )[0]
+
+    json_str = MessageToJson(pp)
+    round_tripped = Parse(json_str, pps2.Phenopacket())
+
+    assert round_tripped == pp

--- a/tests/data/viewpoint_hl7_full_exam_test.txt
+++ b/tests/data/viewpoint_hl7_full_exam_test.txt
@@ -1,0 +1,31 @@
+MSH|^~\&|GE|ViewPoint|Discrete||20260115140000||ORU^R01|22|P|2.4|||AL|NE||8859/15
+PID|||MRN0000022^^^MRN||Full^Sally||19880401|F|||300 Test Boulevard^^Faketown^NY^10003^USA||3334445555^6667778888|6667778888||M|||987-65-4321
+PV1||O|OB^102^1^OBWEST|||OB^102^1^OBWEST||5555^DOCTOR^ATTENDING^^^^^^^^^^^^^^U_Attending_physician|||||||||||VISIT99020||||||||||||||||||||OB|||||20260115133000
+ZED|920^SecondTrimesterUltrasound^2nd Trim.^Second Trimester Ultrasound|ordered^^A1TESTG^20260115133000~new_1^admin^A1TESTG^20260115140000||128^Obstetrics|5555^DOCTOR^ATTENDING^^^^^^^^^^^^^^U_Attending_physician||admin|||VISIT99020|||Default department
+ORC|CN|VISIT99020^^VISIT99020|920|||||||||5555^DOCTOR^ATTENDING||||Full second trimester survey|||||OB
+OBR|1|VISIT99020|920|IMGABS1^AABBSS^^VISIT99021^Second Trimester Ultrasound|||20260115140000||||||Full second trimester survey|||5555^DOCTOR^ATTENDING||||||20260115140000|||P||||||^Full second trimester survey
+OBX|1|ST|Fetus.Identifier^Fetus Identifier|Fetus1|A|||||||||20260115140000
+OBX|2|NM|SkullFetus.HeadCircumference^HC|Fetus1|205^205.0|mm&millimeters^mm&millimeters||||||||20260115140000
+OBX|3|NM|SkullFetus.VP_HeadCircumference_GA|Fetus1|150^21w 3d|d&weeks_days^fmt&formatted||||||||20260115140000
+OBX|4|NM|SkullFetus.VP_HeadCircumference_Percentile|Fetus1|45^45%|%&percent^fmt&formatted||||||||20260115140000
+OBX|5|NM|SkullFetus.BiParietalDiameter^BPD|Fetus1|53^53.0|mm&millimeters^mm&millimeters||||||||20260115140000
+OBX|6|NM|SkullFetus.VP_BiParietalDiameter_GA|Fetus1|149^21w 2d|d&weeks_days^fmt&formatted||||||||20260115140000
+OBX|7|NM|SkullFetus.VP_BiParietalDiameter_Percentile|Fetus1|40^40%|%&percent^fmt&formatted||||||||20260115140000
+OBX|8|NM|AbdomenFetus.AbdominalCircumference^AC|Fetus1|168^168.0|mm&millimeters^mm&millimeters||||||||20260115140000
+OBX|9|NM|AbdomenFetus.VP_AbdominalCircumference_GA|Fetus1|151^21w 4d|d&weeks_days^fmt&formatted||||||||20260115140000
+OBX|10|NM|AbdomenFetus.VP_AbdominalCircumference_Percentile|Fetus1|38^38%|%&percent^fmt&formatted||||||||20260115140000
+OBX|11|NM|ExtremitiesFetus.FemurLength^FL|Fetus1|34^34.0|mm&millimeters^mm&millimeters||||||||20260115140000
+OBX|12|NM|ExtremitiesFetus.VP_FemurLength_GA|Fetus1|150^21w 3d|d&weeks_days^fmt&formatted||||||||20260115140000
+OBX|13|NM|ExtremitiesFetus.VP_FemurLength_Percentile|Fetus1|42^42%|%&percent^fmt&formatted||||||||20260115140000
+OBX|14|ST|BrainFetus.BrainAppearance^Brain appearance|Fetus1|normal|||||||||20260115140000
+OBX|15|ST|BrainFetus.CerebellumAppearance^Cerebellum appearance|Fetus1|abnormal|||||||||20260115140000
+OBX|16|ST|BrainFetus.CerebellumDetails^Cerebellum details|Fetus1|cerebellar hypoplasia|||||||||20260115140000
+OBX|17|ST|FaceFetus.FaceAppearance^Face appearance|Fetus1|normal|||||||||20260115140000
+OBX|18|ST|ChestFetus.ChestAppearance^Chest appearance|Fetus1|normal|||||||||20260115140000
+OBX|19|ST|GastrointestinalTractFetus.GastrointestinalTractAppearance^GI tract appearance|Fetus1|normal|||||||||20260115140000
+OBX|20|ST|SpineFetus.SpineAppearance^Spine appearance|Fetus1|normal|||||||||20260115140000
+OBX|21|ST|UrinaryTractFetus.BladderAppearance^Bladder appearance|Fetus1|normal|||||||||20260115140000
+OBX|22|ST|UrinaryTractFetus.UrogenitalTractAppearance^Urogenital tract appearance|Fetus1|normal|||||||||20260115140000
+OBX|23|ST|UrinaryTractFetus.KidneyLAppearance^Left kidney appearance|Fetus1|normal|||||||||20260115140000
+OBX|24|ST|UrinaryTractFetus.KidneyRAppearance^Right kidney appearance|Fetus1|normal|||||||||20260115140000
+OBX|25|ST|RequestedProcedure.Indication^Indication^Order indication|1|Full second trimester survey; anomaly follow-up|||||||||20260115140000


### PR DESCRIPTION
## Summary
- New `build_viewpoint_phenopacket()`, mirroring `build_observer_phenopacket`'s shape - one Phenopacket per fetus, biometry + narrative + anatomy features, HPO dedup, the real pregnancy-aware subject-id from #102.
- Self-contained builder file (no cross-file private-helper imports), matching the convention `gyn_phenopacket.py` (#104) established.
- New combined fixture `viewpoint_hl7_full_exam_test.txt` (biometry + all 16 anatomy fields) - the #107 anatomy-only fixture alone can't exercise the builder (fetus grouping is keyed off biometry).

## Test plan
- [x] `uv run --extra dev pytest -q`
- [x] `uv run --extra dev ruff check` / `ruff format --check`