### PR TITLE
TODO scaffolding for cardiac echo parsing and known quirks (#93)

### DIFF
--- a/src/prenatalppkt/builders/observer_phenopacket.py
+++ b/src/prenatalppkt/builders/observer_phenopacket.py
@@ -5,6 +5,13 @@ module stitches `extract_all_fetuses` output together with the exam-level
 section parses (impression, anatomy, EFW, pregnancy dating) and returns
 one `Phenopacket` per fetus. The caller decides what to do with fetuses
 that yielded no phenotypic features (UNKNOWN scan type, missing biometry).
+
+TODO @VarenyaJ: this module's private helpers (_resolve_subject_ga,
+_biometry_feature, _narrative_feature, _dedup_by_hpo_id, _hpo_resource,
+_phenopacket_id, _subject_id) are now duplicated near-verbatim across
+three builder files (this one, gyn_phenopacket.py, viewpoint_phenopacket.py)
+by deliberate choice - each builder was kept self-contained rather than
+sharing a utils module across 2 files. Worth revisiting now that it's 3.
 """
 
 from __future__ import annotations
@@ -39,6 +46,11 @@ def _parse_ga_from_description(description: str) -> Optional[tuple[int, int]]:
 
 
 def _resolve_subject_ga(dating: dict, term_bins: list[TermBin]) -> GestationalAge:
+    # TODO @VarenyaJ: dating.get("ga_weeks") is dead code today -
+    # _parse_observer_pregnancy returns ga_by_lmp/ga_by_ultrasound/
+    # assigned_ga, never a "ga_weeks" key, so this branch never fires
+    # and GA always falls through to the description-parsing loop below
+    # (or the 27w0d default).
     ga_weeks = dating.get("ga_weeks")
     if ga_weeks:
         return GestationalAge.from_weeks(float(ga_weeks))

--- a/src/prenatalppkt/builders/viewpoint_phenopacket.py
+++ b/src/prenatalppkt/builders/viewpoint_phenopacket.py
@@ -5,6 +5,14 @@ This module stitches `extract_all_fetuses` output together with the
 exam-level section parses (impression, anatomy, pregnancy dating) and
 returns one `Phenopacket` per fetus. The caller decides what to do with
 fetuses that yielded no phenotypic features.
+
+TODO @VarenyaJ: this module's private helpers (_resolve_subject_ga,
+_biometry_feature, _narrative_feature, _dedup_by_hpo_id, _hpo_resource,
+_phenopacket_id, _subject_id) are now duplicated near-verbatim across
+three builder files (this one, observer_phenopacket.py,
+gyn_phenopacket.py) by deliberate choice - each builder was kept
+self-contained rather than sharing a utils module across 2 files.
+Worth revisiting now that it's 3.
 """
 
 from __future__ import annotations
@@ -38,6 +46,12 @@ def _parse_ga_from_description(description: str) -> Optional[tuple[int, int]]:
 
 
 def _resolve_subject_ga(dating: dict, term_bins: list[TermBin]) -> GestationalAge:
+    # TODO @VarenyaJ: dating.get("ga_weeks") is dead code today -
+    # _parse_viewpoint_hl7_pregnancy returns ga_by_lmp/ga_by_ultrasound/
+    # assigned_ga, never a "ga_weeks" key, so this branch never fires
+    # and GA always falls through to the description-parsing loop below
+    # (or the 27w0d default). Same quirk as observer_phenopacket.py's
+    # copy of this function.
     ga_weeks = dating.get("ga_weeks")
     if ga_weeks:
         return GestationalAge.from_weeks(float(ga_weeks))

--- a/src/prenatalppkt/etl/sections/__init__.py
+++ b/src/prenatalppkt/etl/sections/__init__.py
@@ -17,6 +17,7 @@ Skeleton parsers (TODO):
 - parse_placenta: Placental assessment
 - parse_amniotic_fluid: AFI, MVP measurements
 - parse_umbilical_cord: Vessel count, insertion site
+- parse_fetal_echo: Cardiac structure findings and measurements
 """
 
 from prenatalppkt.etl.sections.maternal_history import parse_maternal_history
@@ -31,6 +32,7 @@ from prenatalppkt.etl.sections.fetal_ratios import parse_fetal_ratios
 from prenatalppkt.etl.sections.placenta import parse_placenta
 from prenatalppkt.etl.sections.amniotic_fluid import parse_amniotic_fluid
 from prenatalppkt.etl.sections.umbilical_cord import parse_umbilical_cord
+from prenatalppkt.etl.sections.fetal_echo import parse_fetal_echo
 
 __all__ = [
     "parse_maternal_history",
@@ -43,4 +45,5 @@ __all__ = [
     "parse_placenta",
     "parse_amniotic_fluid",
     "parse_umbilical_cord",
+    "parse_fetal_echo",
 ]

--- a/src/prenatalppkt/etl/sections/clinical_impression.py
+++ b/src/prenatalppkt/etl/sections/clinical_impression.py
@@ -176,6 +176,12 @@ def _infer_growth_assessment(text: str) -> Optional[str]:
         "LGA" - Large for Gestational Age
         "AGA" - Appropriate for Gestational Age
         None - No assessment detected
+
+    TODO @VarenyaJ: this is a naive substring match on the impression
+    text, not a computed classification from actual percentiles, and
+    neither build_observer_phenopacket nor build_viewpoint_phenopacket
+    reads "growth_assessment" from parse_clinical_impression's output
+    today - the value is computed here but never consumed.
     """
     if not text:
         return None

--- a/src/prenatalppkt/etl/sections/fetal_echo.py
+++ b/src/prenatalppkt/etl/sections/fetal_echo.py
@@ -1,0 +1,75 @@
+"""
+Fetal echocardiography section parser (SKELETON).
+
+Real cardiac data exists in both Observer JSON and ViewPoint HL7, but
+nothing parses it yet. The field names below were found in the data
+dictionary (scripts/data_dict/), not guessed.
+
+TODO @VarenyaJ: Complete implementation - map cardiac structure states to
+HPO terms and decide whether the embedded numeric echo measurements
+(aortic root diameter, ventricle dimensions, valve Zscore diameters) get
+parsed here or handled separately, since those need new
+BiometryMeasurement enum members and growth-reference curves - the same
+clinical-authority gap as the SGA/LGA growth classification.
+"""
+
+from typing import Dict
+
+
+def parse_fetal_echo(data, source_format: str, hpo_cr=None) -> Dict:
+    """
+    Parse fetal echocardiography section.
+
+    Args:
+        data: Raw input data (JSON string, dict, or text)
+        source_format: One of "observer_json", "viewpoint_text", "viewpoint_hl7"
+        hpo_cr: Optional concept recognizer for HPO term extraction from
+                free-text findings.
+
+    Returns:
+        Dict with keys:
+            - normal_structures: List[str] - Cardiac structures marked Normal
+            - abnormal_structures: List[str] - Cardiac structures marked Abnormal
+            - not_visualized: List[str] - Cardiac structures marked Unseen
+            - findings: List[Dict] - Specific cardiac findings (structure + description)
+            - hpo_terms: List[SimpleTerm] - HPO terms extracted from findings
+            - source_format: str
+
+    TODO @VarenyaJ Implementation steps:
+        1. Observer JSON: fetuses[].fetal_echo_anatomy[] uses the exact
+           same main.label / main.anat_state / detail[] / anomalies[]
+           shape as fetuses[].fetus.anatomy[] (the regular anatomy
+           parser) - reuse _process_anatomy_item / _classify_structure
+           from fetal_anatomy.py rather than rewriting that logic.
+        2. ViewPoint HL7: HeartFetus.HeartAppearance and
+           HeartFetus.VisceroAtrialSitusAppearance are the top-level
+           state fields (normal/abnormal/suboptimal - same 3-value
+           vocabulary as the regular anatomy fields). About 11 *Details
+           free-text fields (AortaAscDetails, AorticIsthmusDetails,
+           AtriaDetails, AtrioVentricularConnectionsDetails,
+           GreatArteryCrossingDetails, HeartDetails,
+           PulmonaryArtery{L,Main,R}Details,
+           VenousAtrialConnectionsDetails,
+           VentricleArteryConnectionsDetails, VentriclesDetails) feed
+           HPO extraction the same way the regular anatomy Details
+           fields do.
+        3. Cardiac also has several coded findings with no equivalent in
+           the regular anatomy parser: CardiacRhythm, CardiacFunction,
+           CardiacPosition, CardiacProportions, CardiacSize,
+           PericardialEffusion, IntracardiacEchogenicFocusPrint - each
+           needs its own HPO-mapping design, not just a
+           Normal/Abnormal/Unseen classification.
+        4. Numeric echo measurements (Observer's fetuses[].dm_echo.* -
+           aortic root diameter, biventricular dimensions,
+           interventricular septum, left/right ventricle; ViewPoint's
+           roughly 40 valve annulus diameter + Zscore fields) are a
+           separate, larger decision - not attempted here.
+    """
+    return {
+        "normal_structures": [],
+        "abnormal_structures": [],
+        "not_visualized": [],
+        "findings": [],
+        "hpo_terms": [],
+        "source_format": source_format,
+    }

--- a/src/prenatalppkt/scripts/data_dict/concept_aliases.yaml
+++ b/src/prenatalppkt/scripts/data_dict/concept_aliases.yaml
@@ -339,3 +339,126 @@ anatomy.kidney_right.state:
       label: Right kidney
   viewpoint:
     - UrinaryTractFetus.KidneyRAppearance
+
+# ---------------------------------------------------------------
+# Cardiac - structure state and free-text finding. Observer's
+# fetal_echo_anatomy[] items use the same shape as the regular
+# fetus.anatomy[] items (main.label/anat_state, anomalies[].
+# description), disambiguated by label the same way. ViewPoint
+# identifiers confirmed via comparison.csv. Numeric echo
+# measurements (dm_echo, valve Zscore fields) are a separate,
+# larger scope - not covered here, see the skeleton parser
+# etl/sections/fetal_echo.py.
+# ---------------------------------------------------------------
+
+cardiac.heart.state:
+  description: Overall heart structure normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].main.anat_state
+      label: Heart
+  viewpoint:
+    - HeartFetus.HeartAppearance
+
+cardiac.heart.finding:
+  description: Overall heart free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].anomalies[].description
+      label: Heart
+  viewpoint:
+    - HeartFetus.HeartDetails
+
+cardiac.viscero_atrial_situs.state:
+  description: Viscero-atrial situs (organ arrangement) normal/abnormal/unseen state
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].main.anat_state
+      label: Viscero-atrial situs
+  viewpoint:
+    - HeartFetus.VisceroAtrialSitusAppearance
+
+cardiac.ascending_aorta.finding:
+  description: Ascending aorta free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].anomalies[].description
+      label: Ascending aorta
+  viewpoint:
+    - HeartFetus.AortaAscDetails
+
+cardiac.aortic_isthmus.finding:
+  description: Aortic isthmus free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].anomalies[].description
+      label: Aortic isthmus
+  viewpoint:
+    - HeartFetus.AorticIsthmusDetails
+
+cardiac.atria.finding:
+  description: Atria free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].anomalies[].description
+      label: Atria
+  viewpoint:
+    - HeartFetus.AtriaDetails
+
+cardiac.atrioventricular_connections.finding:
+  description: Atrioventricular connections free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].anomalies[].description
+      label: Atrioventricular connections
+  viewpoint:
+    - HeartFetus.AtrioVentricularConnectionsDetails
+
+cardiac.great_artery_crossing.finding:
+  description: Great artery crossing free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].anomalies[].description
+      label: Great artery crossing
+  viewpoint:
+    - HeartFetus.GreatArteryCrossingDetails
+
+cardiac.pulmonary_artery_left.finding:
+  description: Left pulmonary artery free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].anomalies[].description
+      label: Left pulmonary artery
+  viewpoint:
+    - HeartFetus.PulmonaryArteryLDetails
+
+cardiac.pulmonary_artery_main.finding:
+  description: Main pulmonary artery free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].anomalies[].description
+      label: Main pulmonary artery
+  viewpoint:
+    - HeartFetus.PulmonaryArteryMainDetails
+
+cardiac.pulmonary_artery_right.finding:
+  description: Right pulmonary artery free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].anomalies[].description
+      label: Right pulmonary artery
+  viewpoint:
+    - HeartFetus.PulmonaryArteryRDetails
+
+cardiac.venous_atrial_connections.finding:
+  description: Venous atrial connections free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].anomalies[].description
+      label: Venous atrial connections
+  viewpoint:
+    - HeartFetus.VenousAtrialConnectionsDetails
+
+cardiac.ventricle_artery_connections.finding:
+  description: Ventricle-artery connections free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].anomalies[].description
+      label: Ventricle-artery connections
+  viewpoint:
+    - HeartFetus.VentricleArteryConnectionsDetails
+
+cardiac.ventricles.finding:
+  description: Ventricles free-text finding (present when abnormal)
+  observer:
+    - path: fetuses[].fetal_echo_anatomy[].anomalies[].description
+      label: Ventricles
+  viewpoint:
+    - HeartFetus.VentriclesDetails


### PR DESCRIPTION
## Summary
- New skeleton `etl/sections/fetal_echo.py`
- New `cardiac.*` section in `concept_aliases.yaml` documenting the Observer `fetal_echo_anatomy[]` <-> ViewPoint `HeartFetus.*` correspondence - documentation only, the parser itself stays a skeleton.
- TODO comments only (zero behavior change) on: `_resolve_subject_ga` in both `observer_phenopacket.py` and `viewpoint_phenopacket.py` (a `dating.get("ga_weeks")` dead-key quirk - that key is never actually returned by either pregnancy-dating parser), `clinical_impression.py`'s `_infer_growth_assessment` (computed but never consumed by either builder), and a note on all builder files about now having 3x-duplicated private helpers worth revisiting.
- Full details will probably need an issue e.g. "Cardiac and Full Anatomy Parity"