### PR TITLE
Extract RelevantClinicalInfo from ViewPoint HL7 impressions

### DIFF
--- a/src/prenatalppkt/etl/sections/clinical_impression.py
+++ b/src/prenatalppkt/etl/sections/clinical_impression.py
@@ -139,8 +139,8 @@ def _parse_viewpoint_hl7_impression(hl7: str) -> str:
     """
     Extract impression from HL7 ORU^R01 messages.
 
-    Looks for OBX segments containing "Impression" or "Interpretation"
-    in the observation identifier field.
+    Looks for OBX segments containing "Impression", "Interpretation", or
+    "RelevantClinicalInfo" in the observation identifier field.
     """
     lines: List[str] = []
 
@@ -155,7 +155,11 @@ def _parse_viewpoint_hl7_impression(hl7: str) -> str:
         obs_id = fields[3]
         value = fields[5].split("^")[0].strip()
 
-        if "Impression" in obs_id or "Interpretation" in obs_id:
+        if (
+            "Impression" in obs_id
+            or "Interpretation" in obs_id
+            or "RelevantClinicalInfo" in obs_id
+        ):
             if value:
                 lines.append(value)
 

--- a/tests/etl/sections/test_clinical_impression.py
+++ b/tests/etl/sections/test_clinical_impression.py
@@ -73,6 +73,20 @@ class TestClinicalImpressionViewPointHL7:
         assert "Appropriate" in result["impression_text"]
         assert result["growth_assessment"] == "AGA"
 
+    def test_relevant_clinical_info_extracted(self, hpo_cr):
+        """RequestedProcedure.RelevantClinicalInfo used to be silently
+        dropped - it matches neither "Impression" nor "Interpretation".
+        Real OBX line shape from tests/data/viewpoint_hl7_test.txt."""
+        hl7 = (
+            "OBX|118|ST|RequestedProcedure.RelevantClinicalInfo^Relevant "
+            "clinical info^Relevant clinical information|1|Suspected "
+            "Dandy-Walker malformation|||||||||20251230162536\n"
+        )
+
+        result = parse_clinical_impression(hl7, "viewpoint_hl7", hpo_cr=hpo_cr)
+
+        assert "Dandy-Walker malformation" in result["impression_text"]
+
 
 # ---------------------------------------------------------------------
 # Real Observer fixtures - ground truth confirmed by hand

--- a/tests/hpo/test_fenominal_cr.py
+++ b/tests/hpo/test_fenominal_cr.py
@@ -36,3 +36,46 @@ def test_parse_coerces_non_string_input(fenominal_cr):
 
 def test_parse_empty_text_returns_empty(fenominal_cr):
     assert fenominal_cr.parse("") == []
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Known fenominal gap: the exact HPO label 'Dandy-Walker "
+        "malformation' returns zero hits, including in total isolation "
+        "(not a sentence-context problem). See "
+        "test_fetal_anatomy.py's matching xfail for the same gap at "
+        "the section-parser level. Remove once fenominal (or a "
+        "fallback recognizer) recognizes the phrase."
+    ),
+    strict=True,
+)
+def test_parse_recognizes_dandy_walker_malformation(fenominal_cr):
+    terms = fenominal_cr.parse("Dandy-Walker malformation")
+    by_id = {t.hpo_id: t for t in terms}
+    assert "HP:0001305" in by_id
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Known fenominal gap: negation scope leaks on multi-item "
+        "comma/'or' lists. Given 'no evidence of macrocephaly, "
+        "ventriculomegaly or agenesis of the corpus callosum' (one "
+        "clause negating three findings), fenominal correctly excludes "
+        "the first two but not the third, despite identical "
+        "grammatical scope. Reproduced on the isolated clause here, "
+        "not just the full paragraph, so it's a real parsing behavior, "
+        "not sentence-context noise. Remove once fenominal (or a "
+        "fallback recognizer) handles multi-item negated lists "
+        "correctly."
+    ),
+    strict=True,
+)
+def test_parse_negation_scope_covers_full_list(fenominal_cr):
+    terms = fenominal_cr.parse(
+        "There was no evidence of macrocephaly, ventriculomegaly or "
+        "agenesis of the corpus callosum."
+    )
+    by_id = {t.hpo_id: t for t in terms}
+    assert by_id["HP:0000256"].excluded is True  # Macrocephaly
+    assert by_id["HP:0002119"].excluded is True  # Ventriculomegaly
+    assert by_id["HP:0001274"].excluded is True  # Agenesis of corpus callosum


### PR DESCRIPTION
Fixes a silent extraction bug: `_parse_viewpoint_hl7_impression` only matched OBX-3 identifiers containing `Impression` or `Interpretation` - the real field `RequestedProcedure.RelevantClinicalInfo` matched neither and was never extracted, so no recognizer ever saw that text.

Also formalizes two known `fenominal` gaps and checked-in `xfail` tests